### PR TITLE
FEATURE: supports spring 4.3.0 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     <version>1.9.7</version>
 
     <properties>
-        <org.springframework.version>3.1.0.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
         <org.slf4j.version>1.5.10</org.slf4j.version>
-        <arcus.client.version>1.9.7</arcus.client.version>
+        <arcus.client.version>1.11.4</arcus.client.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
+            <version>4.12</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/com/navercorp/arcus/spring/concurrent/DefaultKeyLockProvider.java
+++ b/src/main/java/com/navercorp/arcus/spring/concurrent/DefaultKeyLockProvider.java
@@ -1,0 +1,42 @@
+package com.navercorp.arcus.spring.concurrent;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+@SuppressWarnings("WeakerAccess")
+public class DefaultKeyLockProvider implements KeyLockProvider {
+
+  public static final int DEFAULT_EXPONENT_OF_LOCKS = 11;
+
+  private final ReadWriteLock[] mutexes;
+
+  public DefaultKeyLockProvider() {
+    this(DEFAULT_EXPONENT_OF_LOCKS);
+  }
+
+  public DefaultKeyLockProvider(int exponentOfLocks) {
+    if (exponentOfLocks < 0) {
+      exponentOfLocks = DEFAULT_EXPONENT_OF_LOCKS;
+    }
+
+    int numberOfLocks = (int) Math.pow(2, exponentOfLocks);
+
+    mutexes = new ReadWriteLock[numberOfLocks];
+    for (int i = 0; i < numberOfLocks; i++) {
+      mutexes[i] = new ReentrantReadWriteLock();
+    }
+  }
+
+  @Override
+  public ReadWriteLock getLockForKey(Object key) {
+    return mutexes[selectLock(key)];
+  }
+
+  private int selectLock(Object key) {
+    if (key == null) {
+      return 0;
+    }
+    return key.hashCode() & (mutexes.length - 1);
+  }
+
+}

--- a/src/main/java/com/navercorp/arcus/spring/concurrent/KeyLockProvider.java
+++ b/src/main/java/com/navercorp/arcus/spring/concurrent/KeyLockProvider.java
@@ -1,0 +1,9 @@
+package com.navercorp.arcus.spring.concurrent;
+
+import java.util.concurrent.locks.ReadWriteLock;
+
+public interface KeyLockProvider {
+
+  ReadWriteLock getLockForKey(Object key);
+
+}

--- a/src/test/java/com/navercorp/arcus/spring/concurrent/DefaultKeyLockProviderTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/concurrent/DefaultKeyLockProviderTest.java
@@ -1,0 +1,74 @@
+package com.navercorp.arcus.spring.concurrent;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class DefaultKeyLockProviderTest {
+
+  private int count = 0;
+
+  @Test
+  public void testArrayIndexOufOfBoundsExceptionNotThrown() {
+    Set<Integer> hashCodeSet = new HashSet<Integer>();
+
+    int exponentOfLocks = 12;
+    int numberOfLocks = (int) Math.pow(2, exponentOfLocks);
+
+    DefaultKeyLockProvider provider = new DefaultKeyLockProvider(exponentOfLocks);
+
+    hashCodeSet.add(provider.getLockForKey(null).hashCode());
+    
+    for (int i = 0; i < numberOfLocks * 2; i++) {
+      hashCodeSet.add(provider.getLockForKey(new TestObject(i)).hashCode());
+    }
+
+    assertEquals(hashCodeSet.size(), numberOfLocks);
+  }
+
+  @Test
+  public void testConcurrency() throws InterruptedException {
+    final DefaultKeyLockProvider provider = new DefaultKeyLockProvider();
+    final TestObject key = new TestObject(0);
+    final int maxCount = 10000;
+    final Runnable runnable = new Runnable() {
+      @Override
+      public void run() {
+        for (int i = 0; i < maxCount; i++) {
+          provider.getLockForKey(key).writeLock().lock();
+          count++;
+          provider.getLockForKey(key).writeLock().unlock();
+        }
+      }
+    };
+
+    Thread[] threads = new Thread[] { new Thread(runnable), new Thread(runnable), new Thread(runnable) };
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    assertEquals(count, maxCount * threads.length);
+  }
+
+  static class TestObject {
+
+    private int i;
+
+    TestObject(int i) {
+      this.i = i;
+    }
+
+    @Override
+    public int hashCode() {
+      return i;
+    }
+
+  }
+
+}


### PR DESCRIPTION
- Spring 4.0~4.3 에서 추가된 3가지 Cache interface
(https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/Cache.html) 
를 ArcusCache 클래스에 추가하여, Spring4 Cache 사용시 구현되지 않은 Cache Interface가 호출됨에 따라 AbstractMethodError가 발생되는 문제를 해결하였습니다.

- Spring Cache를 사용할 수 있는 최소 버전 3.1.0.RELEASE에서 테스트를 하여 아무 이상없이 동작됨을 확인하였습니다. (Spring 4에서 제공되는 클래스를 사용하지 않았기 때문에, NoClassDefFoundError와 같은 에러는 발생하지 않았습니다.)

- arcus-java-client 버전은 최신 버전으로 변경하였습니다.

- 기존 테스트 코드 중에 warning이 발견된 부분이 있어, 적절한 assert 메소드를 사용하여 fix 하였습니다.