### PR TITLE
FEATURE: Implement ArcusCacheManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.9.7</version>
 
     <properties>
-        <org.springframework.version>3.1.0.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
         <org.slf4j.version>1.5.10</org.slf4j.version>
         <arcus.client.version>1.9.7</arcus.client.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
+            <version>4.12</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -28,6 +28,7 @@ import org.springframework.cache.support.SimpleValueWrapper;
 import org.springframework.util.Assert;
 import org.springframework.util.DigestUtils;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -88,6 +89,24 @@ public class ArcusCache implements Cache, InitializingBean {
   @Override
   public Object getNativeCache() {
     return this.arcusClient;
+  }
+
+  // TODO: REMOVE AFTER #8
+  @Override
+  public <T> T get(Object o, Class<T> aClass) {
+    return null;
+  }
+
+  // TODO: REMOVE AFTER #8
+  @Override
+  public <T> T get(Object o, Callable<T> callable) {
+    return null;
+  }
+
+  // TODO: REMOVE AFTER #8
+  @Override
+  public ValueWrapper putIfAbsent(Object o, Object o1) {
+    return null;
   }
 
   @Override

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheManager.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheManager.java
@@ -1,0 +1,109 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2011-2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache;
+
+import net.spy.memcached.ArcusClient;
+import net.spy.memcached.ArcusClientPool;
+import net.spy.memcached.ConnectionFactoryBuilder;
+import net.spy.memcached.transcoders.Transcoder;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.AbstractCacheManager;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 스프링 CacheManager의 Arcus 구현체.
+ *
+ * 미리 정의하지 않은 이름의 캐시에 대해 get 요청을 받으면 (SimpleCacheManager와 다르게) 기본 설정으로 새 캐시를 생성하고 저장합니다.
+ */
+public class ArcusCacheManager extends AbstractCacheManager implements DisposableBean {
+  private final ArcusClientPool arcusClientPool;
+  private final String serviceId;
+  private final Transcoder<Object> operationTranscoder;
+  private final int timeoutMillis;
+  private final int defaultExpireSeconds;
+  private final Map<String, Integer> nameToExpireSeconds;
+  private final boolean wantToGetException;
+
+  public ArcusCacheManager(
+    String adminAddress,
+    String serviceCode,
+    String serviceId,
+    ConnectionFactoryBuilder connectionFactoryBuilder,
+    Transcoder<Object> operationTranscoder,
+    int poolSize,
+    int timeoutMillis,
+    int defaultExpireSeconds,
+    Map<String, Integer> nameToExpireSeconds,
+    boolean wantToGetException) {
+
+    this.arcusClientPool =
+      ArcusClient.createArcusClientPool(adminAddress, serviceCode, connectionFactoryBuilder, poolSize);
+    this.serviceId = serviceId;
+    this.operationTranscoder = operationTranscoder;
+    this.timeoutMillis = timeoutMillis;
+    this.defaultExpireSeconds = defaultExpireSeconds;
+    this.nameToExpireSeconds = nameToExpireSeconds;
+    this.wantToGetException = wantToGetException;
+  }
+
+  @Override
+  protected Collection<? extends Cache> loadCaches() {
+    List<Cache> caches = new ArrayList<Cache>(this.nameToExpireSeconds.size());
+    for (Map.Entry<String, Integer> nameAndExpireSeconds : this.nameToExpireSeconds.entrySet()) {
+      caches.add(
+        this.createCache(nameAndExpireSeconds.getKey(), nameAndExpireSeconds.getValue()));
+    }
+
+    return caches;
+  }
+
+  @Override
+  protected Cache getMissingCache(String name) {
+    return this.createCache(name, this.defaultExpireSeconds);
+  }
+
+  /**
+   * 캐시를 생성합니다.
+   *
+   * @param name          생성할 캐시 이름
+   * @param expireSeconds 생성할 캐시의 TTL (초)
+   * @return 생성된 캐시
+   */
+  private Cache createCache(String name, int expireSeconds) {
+    ArcusCache cache = new ArcusCache();
+    cache.setName(name);
+    cache.setExpireSeconds(expireSeconds);
+    cache.setServiceId(this.serviceId);
+    cache.setTimeoutMilliSeconds(this.timeoutMillis);
+    cache.setArcusClient(this.arcusClientPool);
+    cache.setOperationTranscoder(this.operationTranscoder);
+    cache.setWantToGetException(this.wantToGetException);
+
+    return cache;
+  }
+
+  @Override
+  public void destroy() {
+    this.arcusClientPool.shutdown();
+  }
+}

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerTest.java
@@ -1,0 +1,113 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2011-2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache;
+
+import net.spy.memcached.ConnectionFactoryBuilder;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+import net.spy.memcached.transcoders.Transcoder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class ArcusCacheManagerTest {
+  private static final String ADMIN_ADDRESS = "127.0.0.1:2181";
+  private static final String SERVICE_CODE = "test";
+  private static final String SERVICE_ID = "test-service-id";
+  private static final Transcoder<Object> DEFAULT_TRANSCODER = new SerializingTranscoder();
+  private static final ConnectionFactoryBuilder CONNECTION_FACTORY_BUILDER = new ConnectionFactoryBuilder();
+  private static final int POOL_SIZE = 4;
+  private static final int TIMEOUT_MILLIS = 100;
+  private static final int DEFAULT_EXPIRE_SECONDS = 1;
+  private static final boolean WANT_TO_GET_EXCEPTION = true;
+  private static final Map<String, Integer> NAME_TO_EXPIRE_SECONDS = new HashMap<String, Integer>();
+  private static final String PRE_DEFINED_CACHE_NAME = "pre-defined-cache";
+  private static final int PRE_DEFINED_EXPIRE_SECONDS = 2;
+  static {
+    NAME_TO_EXPIRE_SECONDS.put(PRE_DEFINED_CACHE_NAME, PRE_DEFINED_EXPIRE_SECONDS);
+  }
+
+  private ArcusCacheManager cacheManager;
+
+  @Before
+  public void setUp() {
+    this.cacheManager = new ArcusCacheManager(
+      ADMIN_ADDRESS,
+      SERVICE_CODE,
+      SERVICE_ID,
+      CONNECTION_FACTORY_BUILDER,
+      DEFAULT_TRANSCODER,
+      POOL_SIZE,
+      TIMEOUT_MILLIS,
+      DEFAULT_EXPIRE_SECONDS,
+      NAME_TO_EXPIRE_SECONDS,
+      WANT_TO_GET_EXCEPTION);
+  }
+
+  @After
+  public void tearDown() {
+    cacheManager.destroy();
+  }
+
+  @Test
+  public void testGetPreDefinedCache() {
+    ArcusCache cache = (ArcusCache)this.cacheManager.getCache(PRE_DEFINED_CACHE_NAME);
+
+    assertEquals(PRE_DEFINED_CACHE_NAME, cache.getName());
+    assertEquals(PRE_DEFINED_EXPIRE_SECONDS, cache.getExpireSeconds());
+    assertEquals(SERVICE_ID, cache.getServiceId());
+    assertEquals(TIMEOUT_MILLIS, cache.getTimeoutMilliSeconds());
+    assertEquals(DEFAULT_TRANSCODER, cache.getOperationTranscoder());
+    assertEquals(WANT_TO_GET_EXCEPTION, cache.isWantToGetException());
+  }
+
+  @Test
+  public void testGetMissingCache() {
+    String nonDefinedCache = "non-defined-cache";
+    ArcusCache cache = (ArcusCache)this.cacheManager.getCache(nonDefinedCache);
+
+    assertEquals(nonDefinedCache, cache.getName());
+    assertEquals(DEFAULT_EXPIRE_SECONDS, cache.getExpireSeconds());
+    assertEquals(SERVICE_ID, cache.getServiceId());
+    assertEquals(TIMEOUT_MILLIS, cache.getTimeoutMilliSeconds());
+    assertEquals(DEFAULT_TRANSCODER, cache.getOperationTranscoder());
+    assertEquals(WANT_TO_GET_EXCEPTION, cache.isWantToGetException());
+  }
+
+  @Test
+  public void testGetPreDefinedCacheNames() {
+    Collection<String> preDefinedCacheNames = this.cacheManager.getCacheNames();
+
+    assertEquals(1, preDefinedCacheNames.size());
+    assertTrue(preDefinedCacheNames.contains(PRE_DEFINED_CACHE_NAME));
+  }
+
+  @Test
+  public void testGetMissingCacheNames() {
+    String nonDefinedCache = "non-defined-cache";
+    this.cacheManager.getCache(nonDefinedCache); // Create missing cache
+    Collection<String> cacheNames = this.cacheManager.getCacheNames();
+
+    assertEquals(2, cacheNames.size());
+    assertTrue(cacheNames.contains(PRE_DEFINED_CACHE_NAME));
+    assertTrue(cacheNames.contains(nonDefinedCache));
+  }
+}


### PR DESCRIPTION
최신 Spring 버전에서 arcus-spring을 사용하려고 했으나 몇 가지 어려움이 있어 필요한 부분만 따로 구현해서 사용했었습니다.
사용이 어려웠던 점 중 하나가 캐시별 TTL 설정이나 미리 정의하지 않은 캐시에 대한 생성을 담당하는 `CacheManager` 구현체의 부재였습니다.

이번에 버전업 작업을 하시는 것으로 보여 자체적으로 구현한 `CacheManager` 구현체를 정리해 PR 보냅니다.

우선 필요한 기능만 넣은 상태여서 최소한의 기능만 있는데, 참고만 하시면 될 것 같습니다.
추후 Builder 패턴으로 생성하게 하거나 Configuration 파일을 별도로 만들어서 캐시별로 설정할 수 있게 하는 등의 고도화도 가능할 것 같습니다.

#8 기준으로 Spring / Junit dependency 버전을 올렸고, `ArcusCache`의 신규 method 구현은 비워놓았습니다.
테스트의 경우 자체적으로 "127.0.0.1:2181"에 test arcus를 띄우는 방법으로 테스트하시는 것 같은데 이 방법을 몰라서 실행해보지는 못했습니다.