### PR TITLE
FEATURE: change maven repo because it no longer supports insecure HTTP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,17 @@
     <repositories>
         <repository>
             <id>maven.release.repository</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Springframework Maven Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
         <repository>
             <id>spring-snapshot-milestone</id>
             <name>Springframework Snapshot Repository</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
https://support.sonatype.com/hc/en-us/articles/360041287334

2020년 1월 15일부터 maven repo를 https로 변경해야 합니다.

현재 pom.xml에서 dependency를 받을 수 없는 상태로 pom.xml을 https로 변경하였습니다.