### PR TITLE
FIX: select lock with mod operation

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/concurrent/DefaultKeyLockProvider.java
+++ b/src/main/java/com/navercorp/arcus/spring/concurrent/DefaultKeyLockProvider.java
@@ -18,6 +18,7 @@
 package com.navercorp.arcus.spring.concurrent;
 
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 @SuppressWarnings("WeakerAccess")
@@ -53,7 +54,7 @@ public class DefaultKeyLockProvider implements KeyLockProvider {
     if (key == null) {
       return 0;
     }
-    return key.hashCode() & (mutexes.length - 1);
+    return key.hashCode() % (mutexes.length - 1);
   }
 
 }


### PR DESCRIPTION
Spring cache의 sync 기능을 사용하여 key에 따른 lock을 획득할 때, array 범위에 벗어나는 index로 lock을 획득할 수 있는 문제가 있어 수정하였습니다.