### PR TITLE
FEATURE: upgrade arcus-java-client version (1.13.0 => 1.13.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
         <org.slf4j.version>1.7.24</org.slf4j.version>
         <org.apache.logging.log4j.version>2.13.3</org.apache.logging.log4j.version>
-        <arcus.client.version>1.13.0</arcus.client.version>
+        <arcus.client.version>1.13.2</arcus.client.version>
         <junit.version>4.13.1</junit.version>
         <org.mockito.version>1.7</org.mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
arcus-java-client 1.13.0 버전에 하위 호환성 및 transcoder 이슈가 존재하여 이를 해결한 버전으로 업그레이드 하였습니다.