### PR TITLE
FEATURE: support front cache for ArcusCache

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
- * Copyright 2019 JaM2in Co., Ltd.
+ * Copyright 2019-2021 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 package com.navercorp.arcus.spring.cache;
 
+import com.navercorp.arcus.spring.cache.front.ArcusFrontCache;
 import net.spy.memcached.transcoders.Transcoder;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -26,8 +27,11 @@ public class ArcusCacheConfiguration implements InitializingBean {
   private String serviceId;
   private String prefix;
   private int expireSeconds;
+  private int frontExpireSeconds;
   private int timeoutMilliSeconds;
   private Transcoder<Object> operationTranscoder;
+  private ArcusFrontCache arcusFrontCache;
+  private boolean forceFrontCaching;
 
   public String getServiceId() {
     return serviceId;
@@ -53,6 +57,14 @@ public class ArcusCacheConfiguration implements InitializingBean {
     this.expireSeconds = expireSeconds;
   }
 
+  public int getFrontExpireSeconds() {
+    return frontExpireSeconds;
+  }
+
+  public void setFrontExpireSeconds(int frontExpireSeconds) {
+    this.frontExpireSeconds = frontExpireSeconds;
+  }
+
   public int getTimeoutMilliSeconds() {
     return timeoutMilliSeconds;
   }
@@ -67,6 +79,22 @@ public class ArcusCacheConfiguration implements InitializingBean {
 
   public void setOperationTranscoder(Transcoder<Object> operationTranscoder) {
     this.operationTranscoder = operationTranscoder;
+  }
+
+  public ArcusFrontCache getArcusFrontCache() {
+    return arcusFrontCache;
+  }
+
+  public void setArcusFrontCache(ArcusFrontCache arcusFrontCache) {
+    this.arcusFrontCache = arcusFrontCache;
+  }
+
+  public boolean isForceFrontCaching() {
+    return forceFrontCaching;
+  }
+
+  public void setForceFrontCaching(boolean forceFrontCaching) {
+    this.forceFrontCaching = forceFrontCaching;
   }
 
   @Override

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheManager.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheManager.java
@@ -115,9 +115,12 @@ public class ArcusCacheManager extends AbstractCacheManager implements Disposabl
     cache.setServiceId(configuration.getServiceId());
     cache.setPrefix(configuration.getPrefix());
     cache.setArcusClient(client);
+    cache.setArcusFrontCache(configuration.getArcusFrontCache());
     cache.setExpireSeconds(configuration.getExpireSeconds());
+    cache.setFrontExpireSeconds(configuration.getFrontExpireSeconds());
     cache.setTimeoutMilliSeconds(configuration.getTimeoutMilliSeconds());
     cache.setOperationTranscoder(configuration.getOperationTranscoder());
+    cache.setForceFrontCaching(configuration.isForceFrontCaching());
     cache.setWantToGetException(true);
 
     return cache;

--- a/src/main/java/com/navercorp/arcus/spring/cache/front/ArcusFrontCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/front/ArcusFrontCache.java
@@ -1,0 +1,27 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2021 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache.front;
+
+public interface ArcusFrontCache {
+
+  Object get(String key);
+  void set(String key, Object value, int expireTime);
+  void delete(String key);
+  void clear();
+
+}

--- a/src/main/java/com/navercorp/arcus/spring/cache/front/DefaultArcusFrontCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/front/DefaultArcusFrontCache.java
@@ -1,0 +1,51 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2021 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache.front;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
+
+public class DefaultArcusFrontCache extends EhArcusFrontCache {
+
+  public DefaultArcusFrontCache(String name,
+                                long maxEntries,
+                                boolean copyOnRead,
+                                boolean copyOnWrite) {
+    super(newCache(name, maxEntries, copyOnRead, copyOnWrite));
+  }
+
+  private static Cache newCache(String name,
+                                long maxEntries,
+                                boolean copyOnRead,
+                                boolean copyOnWrite) {
+    CacheConfiguration configuration = new CacheConfiguration();
+    configuration.setName(name);
+    configuration.setMaxEntriesLocalHeap(maxEntries);
+    configuration.setCopyOnRead(copyOnRead);
+    configuration.setCopyOnWrite(copyOnWrite);
+    configuration.memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU);
+
+    Cache cache = new Cache(configuration, null, null);
+    CacheManager.getInstance().addCache(cache);
+
+    return cache;
+  }
+
+}

--- a/src/main/java/com/navercorp/arcus/spring/cache/front/EhArcusFrontCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/front/EhArcusFrontCache.java
@@ -1,0 +1,55 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2021 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache.front;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.Element;
+
+public class EhArcusFrontCache implements ArcusFrontCache {
+
+  private final Cache cache;
+
+  public EhArcusFrontCache(Cache cache) {
+    this.cache = cache;
+  }
+
+  @Override
+  public Object get(String key) {
+    Element element = cache.get(key);
+    return element != null ? element.getObjectValue() : null;
+  }
+
+  @Override
+  public void set(String key, Object value, int expireTime) {
+    Element element = new Element(key, value);
+    element.setTimeToLive(expireTime);
+    element.setTimeToIdle(0);
+    cache.put(element);
+  }
+
+  @Override
+  public void delete(String key) {
+    cache.remove(key);
+  }
+
+  @Override
+  public void clear() {
+    cache.removeAll();
+  }
+
+}

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
@@ -1,0 +1,1400 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2021 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache;
+
+import com.navercorp.arcus.spring.cache.front.ArcusFrontCache;
+import com.navercorp.arcus.spring.concurrent.KeyLockProvider;
+import net.spy.memcached.ArcusClientPool;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.internal.OperationFuture;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+import net.spy.memcached.transcoders.Transcoder;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.Cache;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class ArcusCacheTest {
+
+  private static final ArcusStringKey ARCUS_STRING_KEY = new ArcusStringKey("KEY");
+  private static final Object VALUE = "VALUE";
+  private static final int EXPIRE_SECONDS = 100;
+  private static final int FRONT_EXPIRE_SECONDS = 50;
+  private static final Transcoder<Object> OPERATION_TRANSCODER = new SerializingTranscoder();
+
+  private ArcusCache arcusCache;
+  private ArcusClientPool arcusClientPool;
+  private ArcusFrontCache arcusFrontCache;
+  private String arcusKey;
+  private Callable<?> valueLoader;
+  private KeyLockProvider keyLockProvider;
+  private ReadWriteLock readWriteLock;
+  private Lock lock;
+
+  @Before
+  public void before() {
+    arcusClientPool = mock(ArcusClientPool.class);
+
+    arcusFrontCache = mock(ArcusFrontCache.class);
+
+    arcusCache = new ArcusCache();
+    arcusCache.setServiceId("SERVICEID");
+    arcusCache.setPrefix("PREFIX");
+    arcusCache.setArcusClient(arcusClientPool);
+
+    arcusKey = arcusCache.createArcusKey(ARCUS_STRING_KEY);
+
+    valueLoader = mock(Callable.class);
+
+    keyLockProvider = mock(KeyLockProvider.class);
+
+    readWriteLock = mock(ReadWriteLock.class);
+
+    lock = mock(Lock.class);
+  }
+
+  @Test
+  public void testGet() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey);
+    assertEquals(VALUE, value.get());
+  }
+
+  @Test
+  public void testGet_OperationTranscoder() {
+    // given
+    arcusCache.setOperationTranscoder(OPERATION_TRANSCODER);
+    when(arcusClientPool.asyncGet(arcusKey, OPERATION_TRANSCODER))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey, OPERATION_TRANSCODER);
+    assertEquals(VALUE, value.get());
+  }
+
+  @Test(expected = TestException.class)
+  public void testGet_WantToGetException() {
+    // given
+    arcusCache.setWantToGetException(true);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.get(ARCUS_STRING_KEY);
+  }
+
+  @Test
+  public void testGet_Exception() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenThrow(new TestException());
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    assertNull(value);
+  }
+
+  @Test
+  public void testGet_FutureException() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFutureException());
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    assertNull(value);
+  }
+
+  @Test
+  public void testGet_FrontCache_CacheHit() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusFrontCache.get(arcusKey))
+        .thenReturn(VALUE);
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, never())
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .get(arcusKey);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertEquals(VALUE, value.get());
+  }
+
+  @Test
+  public void testGet_FrontCache_CacheMiss() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+    when(arcusFrontCache.get(arcusKey))
+        .thenReturn(null);
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .get(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertEquals(VALUE, value.get());
+  }
+
+  @Test
+  public void testGet_FrontCache_Null() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null));
+    when(arcusFrontCache.get(arcusKey))
+        .thenReturn(null);
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .get(arcusKey);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertNull(value);
+  }
+
+  @Test
+  public void testPut() {
+    // given
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+  }
+
+  @Test
+  public void testPut_OperationTranscoder() {
+    // given
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setOperationTranscoder(OPERATION_TRANSCODER);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE, OPERATION_TRANSCODER))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE, OPERATION_TRANSCODER);
+  }
+
+  @Test
+  public void testPut_Null() {
+    // given
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, null))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, null);
+
+    // then
+    verify(arcusClientPool, never())
+        .set(arcusKey, EXPIRE_SECONDS, null);
+  }
+
+  @Test(expected = TestException.class)
+  public void testPut_WantToGetException() {
+    // given
+    arcusCache.setWantToGetException(true);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+  }
+
+  @Test
+  public void testPut_FrontCache() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testPut_FrontCache_Failure() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(false));
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testPut_FrontCache_Failure_ForceFrontCaching() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    arcusCache.setForceFrontCaching(true);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(false));
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testPut_FrontCache_Exception() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testPut_FrontCache_Exception_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testPut_FrontCache_FutureException() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testPut_FrontCache_FutureException_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.put(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+  }
+
+  @Test
+  public void testEvict() {
+    // given
+    when(arcusClientPool.delete(arcusKey))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+  }
+
+  @Test(expected = TestException.class)
+  public void testEvict_WantToGetException() {
+    // given
+    arcusCache.setWantToGetException(true);
+    when(arcusClientPool.delete(arcusKey))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+  }
+
+  @Test
+  public void testEvict_FrontCache() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testEvict_FrontCache_Failure() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenReturn(createOperationFuture(false));
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, never())
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testEvict_FrontCache_Failure_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenReturn(createOperationFuture(false));
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testEvict_FrontCache_Exception() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, never())
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testEvict_FrontCache_Exception_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testEvict_FrontCache_FutureException() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, never())
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testEvict_FrontCache_FutureException_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.delete(arcusKey))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.evict(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .delete(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .delete(arcusKey);
+  }
+
+  @Test
+  public void testClear() {
+    // given
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+  }
+
+  @Test(expected = TestException.class)
+  public void testClear_WantToGetException() {
+    // given
+    arcusCache.setWantToGetException(true);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.clear();
+  }
+
+  @Test
+  public void testClear_FrontCache() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFuture(true));
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, times(1))
+        .clear();
+  }
+
+  @Test
+  public void testClear_FrontCache_Failure() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFuture(false));
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, never())
+        .clear();
+  }
+
+  @Test
+  public void testClear_FrontCache_Failure_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFuture(false));
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, times(1))
+        .clear();
+  }
+
+  @Test
+  public void testClear_FrontCache_Exception() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, never())
+        .clear();
+  }
+
+  @Test
+  public void testClear_FrontCache_Exception_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, times(1))
+        .clear();
+  }
+
+  @Test
+  public void testClear_FrontCache_FutureException() {
+    // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, never())
+        .clear();
+  }
+
+  @Test
+  public void testClear_FrontCache_FutureException_ForceFrontCaching() {
+    // given
+    arcusCache.setForceFrontCaching(true);
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    when(arcusClientPool.flush(arcusCache.getServiceId() + arcusCache.getPrefix()))
+        .thenReturn(createOperationFutureException());
+
+    // when
+    arcusCache.clear();
+
+    // then
+    verify(arcusClientPool, times(1))
+        .flush(arcusCache.getServiceId() + arcusCache.getPrefix());
+    verify(arcusFrontCache, times(1))
+        .clear();
+  }
+
+  @Test
+  public void testGetType() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    Object value = arcusCache.get(ARCUS_STRING_KEY, String.class);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey);
+    assertEquals(VALUE, value);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGetType_DifferentType() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    arcusCache.get(ARCUS_STRING_KEY, Integer.class);
+  }
+
+  @Test(expected = TestException.class)
+  public void testGetType_Exception() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenThrow(new TestException());
+
+    // when
+    arcusCache.get(ARCUS_STRING_KEY, String.class);
+  }
+
+  @Test(expected = TestException.class)
+  public void testGetType_FutureException() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFutureException());
+
+    // when
+    arcusCache.get(ARCUS_STRING_KEY, String.class);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_CacheHit() throws Exception {
+    // given
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    Object value = arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+
+    // then
+    verify(arcusClientPool, times(1)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, never()).call();
+    verify(lock, never()).lock();
+    verify(lock, never()).unlock();
+    assertEquals(VALUE, value);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_SecondCacheHit() throws Exception {
+    // given
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null))
+        .thenReturn(createGetFuture(VALUE));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFutureException());
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    Object value = arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, never()).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertEquals(VALUE, value);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_CacheMiss() throws Exception {
+    // given
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    Object value = arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, times(1)).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, times(1)).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertEquals(VALUE, value);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_Exception() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenThrow(new TestException());
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(1)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, never()).call();
+    verify(lock, never()).lock();
+    verify(lock, never()).unlock();
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_FutureException() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFutureException());
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(1)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, never()).call();
+    verify(lock, never()).lock();
+    verify(lock, never()).unlock();
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_SecondException() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null))
+        .thenThrow(new TestException());
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, never()).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testGetValueLoader_Get_SecondFutureException() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null))
+        .thenReturn(createGetFutureException());
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, never()).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testGetValueLoader_Put_Exception() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenThrow(new TestException());
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, times(1)).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, times(1)).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testGetValueLoader_Put_FutureException() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFutureException());
+    when(valueLoader.call())
+        .thenReturn(VALUE);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, times(1)).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, times(1)).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertNotNull(exception);
+  }
+
+   @Test
+  public void testGetValueLoader_ValueLoader_Null() throws Exception {
+    // given
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenReturn(null);
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    Object value = arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, times(1)).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertNull(value);
+  }
+
+  @Test
+  public void testGetValueLoader_ValueLoader_Exception() throws Exception {
+    // given
+    TestException exception = null;
+    arcusCache.setKeyLockProvider(keyLockProvider);
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(null));
+    when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(valueLoader.call())
+        .thenThrow(new TestException());
+    when(keyLockProvider.getLockForKey(arcusKey))
+        .thenReturn(readWriteLock);
+    when(readWriteLock.writeLock())
+        .thenReturn(lock);
+
+    // when
+    try {
+      arcusCache.get(ARCUS_STRING_KEY, valueLoader);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(2)).asyncGet(arcusKey);
+    verify(arcusClientPool, never()).set(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(valueLoader, times(1)).call();
+    verify(lock, times(1)).lock();
+    verify(lock, times(1)).unlock();
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testPutIfAbsent() {
+    // given
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(arcusClientPool.get(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    Object value = arcusCache.putIfAbsent(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .add(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusClientPool, never())
+        .get(arcusKey);
+    assertNull(value);
+  }
+
+  @Test
+  public void testPutIfAbsent_OperationTranscoder() {
+    // given
+    arcusCache.setOperationTranscoder(OPERATION_TRANSCODER);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE, OPERATION_TRANSCODER))
+        .thenReturn(createOperationFuture(true));
+    when(arcusClientPool.get(arcusKey, OPERATION_TRANSCODER))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    Object value = arcusCache.putIfAbsent(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .add(arcusKey, EXPIRE_SECONDS, VALUE, OPERATION_TRANSCODER);
+    verify(arcusClientPool, never())
+        .get(arcusKey, OPERATION_TRANSCODER);
+    assertNull(value);
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache() {
+     // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    Cache.ValueWrapper value = arcusCache.putIfAbsent(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .add(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusClientPool, never())
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertNull(value);
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_Failure() {
+     // given
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(false));
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE.toString() + VALUE.toString()));
+
+    // when
+    Cache.ValueWrapper value = arcusCache.putIfAbsent(ARCUS_STRING_KEY, VALUE);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .add(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, times(1))
+        .set(arcusKey, VALUE.toString() + VALUE.toString(), FRONT_EXPIRE_SECONDS);
+    assertEquals(VALUE.toString() + VALUE.toString(), value.get());
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_Failure_ForceFrontCaching() {
+    arcusCache.setForceFrontCaching(true);
+    testPutIfAbsent_FrontCache_Failure();
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_Exception() {
+     // given
+    TestException exception = null;
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenThrow(new TestException());
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    try {
+      arcusCache.putIfAbsent(ARCUS_STRING_KEY, VALUE);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(1))
+        .add(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusClientPool, never())
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_Exception_ForceFrontCaching() {
+    arcusCache.setForceFrontCaching(true);
+    testPutIfAbsent_FrontCache_Exception();
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_FutureException() {
+     // given
+    TestException exception = null;
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFutureException());
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    try {
+      arcusCache.putIfAbsent(ARCUS_STRING_KEY, VALUE);
+    } catch (TestException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, times(1))
+        .add(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusClientPool, never())
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_FutureException_ForceFrontCaching() {
+    arcusCache.setForceFrontCaching(true);
+    testPutIfAbsent_FrontCache_FutureException();
+  }
+
+  @Test
+  public void testPutIfAbsent_FrontCache_Null() {
+    // given
+    IllegalArgumentException exception = null;
+    arcusCache.setArcusFrontCache(arcusFrontCache);
+    arcusCache.setExpireSeconds(EXPIRE_SECONDS);
+    arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
+        .thenReturn(createOperationFuture(true));
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(VALUE));
+
+    // when
+    try {
+      arcusCache.putIfAbsent(ARCUS_STRING_KEY, null);
+    } catch (IllegalArgumentException e) {
+      exception = e;
+    }
+
+    // then
+    verify(arcusClientPool, never())
+        .add(arcusKey, EXPIRE_SECONDS, VALUE);
+    verify(arcusClientPool, never())
+        .asyncGet(arcusKey);
+    verify(arcusFrontCache, never())
+        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+    assertNotNull(exception);
+  }
+
+  private static GetFuture<Object> createGetFuture(
+      @SuppressWarnings("SameParameterValue") final Object value) {
+    return new GetFuture<Object>(null, 0) {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public boolean isDone() {
+        return false;
+      }
+
+      @Override
+      public Object get() {
+        return value;
+      }
+
+      @Override
+      public Object get(long timeout, TimeUnit unit) {
+        return value;
+      }
+    };
+  }
+
+  private static GetFuture<Object> createGetFutureException() {
+    return new GetFuture<Object>(null, 0) {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public boolean isDone() {
+        return false;
+      }
+
+      @Override
+      public Object get() {
+        throw new TestException();
+      }
+
+      @Override
+      public Object get(long timeout, TimeUnit unit) {
+        throw new TestException();
+      }
+    };
+  }
+
+  private static OperationFuture<Boolean> createOperationFuture(
+      @SuppressWarnings("SameParameterValue") final Boolean value) {
+    return new OperationFuture<Boolean>(null, 0) {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public boolean isDone() {
+        return false;
+      }
+
+      @Override
+      public Boolean get() {
+        return value;
+      }
+
+      @Override
+      public Boolean get(long timeout, TimeUnit unit) {
+        return value;
+      }
+    };
+  }
+
+  private static OperationFuture<Boolean> createOperationFutureException() {
+    return new OperationFuture<Boolean>(null, 0) {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public boolean isDone() {
+        return false;
+      }
+
+      @Override
+      public Boolean get() {
+        throw new TestException();
+      }
+
+      @Override
+      public Boolean get(long timeout, TimeUnit unit) {
+        throw new TestException();
+      }
+    };
+  }
+
+  private static class TestException extends RuntimeException {
+  }
+
+}

--- a/src/test/java/com/navercorp/arcus/spring/cache/front/DefaultArcusFrontCacheTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/front/DefaultArcusFrontCacheTest.java
@@ -1,0 +1,189 @@
+/*
+ * arcus-spring - Arcus as a caching provider for the Spring Cache Abstraction
+ * Copyright 2021 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.arcus.spring.cache.front;
+
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.ObjectExistsException;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.*;
+
+public class DefaultArcusFrontCacheTest {
+
+  @After
+  public void after() {
+    CacheManager.getInstance().shutdown();
+  }
+
+  @Test(expected = ObjectExistsException.class)
+  public void testConstruct_NameConflict() {
+    new DefaultArcusFrontCache("test", 3L, false, false);
+    new DefaultArcusFrontCache("test", 3L, false, false);
+  }
+
+  @Test
+  public void testMultipleCache() {
+    // given
+    DefaultArcusFrontCache frontCache1 = new DefaultArcusFrontCache("test1", 3L, false, false);
+    DefaultArcusFrontCache frontCache2 = new DefaultArcusFrontCache("test2", 3L, false, false);
+
+    // when
+    frontCache1.set("1", 1, 60);
+    frontCache1.set("2", 2, 60);
+    frontCache1.set("3", 3, 60);
+
+    // then
+    assertEquals(1, frontCache1.get("1"));
+    assertEquals(2, frontCache1.get("2"));
+    assertEquals(3, frontCache1.get("3"));
+    assertNull(frontCache2.get("1"));
+    assertNull(frontCache2.get("2"));
+    assertNull(frontCache2.get("3"));
+  }
+
+  @Test
+  public void testMaxEntries() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, false, false);
+    frontCache.set("1", 1, 60);
+    frontCache.set("2", 2, 60);
+    frontCache.set("3", 3, 60);
+    frontCache.get("1");
+    frontCache.get("2");
+
+    // when
+    frontCache.set("4", 4, 60);
+
+    // then
+    assertEquals(1, frontCache.get("1"));
+    assertEquals(2, frontCache.get("2"));
+    assertNull(frontCache.get("3"));
+    assertEquals(4, frontCache.get("4"));
+  }
+
+  @Test
+  public void testExpires() throws InterruptedException {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, false, false);
+
+    // when
+    frontCache.set("1", 1, 1);
+    Thread.sleep(2000);
+
+    // then
+    assertNull(frontCache.get("1"));
+  }
+
+  @Test
+  public void testCopyOnRead_False() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, false, false);
+    frontCache.set("1", new TestObject(1), 60);
+
+    // when
+    TestObject object = (TestObject) frontCache.get("1");
+    object.value = 2;
+
+    // then
+    assertEquals(object.value, ((TestObject) frontCache.get("1")).value);
+  }
+
+  @Test
+  public void testCopyOnRead_True() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, true, false);
+    frontCache.set("1", new TestObject(1), 60);
+
+    // when
+    TestObject object = (TestObject) frontCache.get("1");
+    object.value = 2;
+
+    // then
+    assertNotEquals(object.value, ((TestObject) frontCache.get("1")).value);
+  }
+
+  @Test
+  public void testCopyOnWrite_False() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, true, false);
+    TestObject object = new TestObject(1);
+    frontCache.set("1", object, 60);
+
+    // when
+    object.value = 2;
+
+    // then
+    assertEquals(object.value, ((TestObject) frontCache.get("1")).value);
+  }
+
+  @Test
+  public void testCopyOnWrite_True() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, true, true);
+    frontCache.set("1", new TestObject(1), 60);
+
+    // when
+    TestObject object = (TestObject) frontCache.get("1");
+    object.value = 2;
+
+    // then
+    assertNotEquals(object.value, ((TestObject) frontCache.get("1")).value);
+  }
+
+  @Test
+  public void testDelete() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, false, false);
+    frontCache.set("1", 1, 60);
+    frontCache.set("2", 2, 60);
+
+    // when
+    frontCache.delete("1");
+
+    // then
+    assertNull(frontCache.get("1"));
+    assertEquals(2, frontCache.get("2"));
+  }
+
+  @Test
+  public void testClear() {
+    // given
+    DefaultArcusFrontCache frontCache = new DefaultArcusFrontCache("test", 3L, false, false);
+    frontCache.set("1", 1, 60);
+    frontCache.set("2", 2, 60);
+
+    // when
+    frontCache.clear();
+
+    // then
+    assertNull(frontCache.get("1"));
+    assertNull(frontCache.get("2"));
+  }
+
+  static class TestObject implements Serializable {
+    public int value = 0;
+
+    public TestObject(int value) {
+      this.value = value;
+    }
+  }
+
+}


### PR DESCRIPTION
기존 arcus-java-client에는 front cache 기능을 지원하지만, front cache 설정이 전역으로 설정되어 캐시 대상별로 세부 설정이 불가능한 문제가 있습니다.

이를 위해 ArcusCache 레벨에서 front cache 기능이 수행될 수 있도록 추가하였습니다. 

- Arcus 캐시 노드 다운시에도 front cache 기능이 동작 가능 (ArcusCache의 `forceFrontCaching`를 true로 설정해야 함)
- ArcusCache 별로 front cache의 expire time을 설정
- ArcusCache 별로 front cache의 세부 설정 가능

추가로, 로그 레벨이 일관성 없게 설정되어 error 메시지 레벨은 info로 변경하였습니다.