### PR TITLE
FEATURE: enables ehcache creation by name and cachemanager for cache …

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/front/EhArcusFrontCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/front/EhArcusFrontCache.java
@@ -18,11 +18,27 @@
 package com.navercorp.arcus.spring.cache.front;
 
 import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 
 public class EhArcusFrontCache implements ArcusFrontCache {
 
   private final Cache cache;
+
+  public EhArcusFrontCache(String name) {
+    this(name, CacheManager.getInstance());
+  }
+
+  public EhArcusFrontCache(String name, CacheManager cacheManager) {
+    Cache cache = cacheManager.getCache(name);
+
+    if (cache == null) {
+      cacheManager.addCache(name);
+      cache = cacheManager.getCache(name);
+    }
+
+    this.cache = cache;
+  }
 
   public EhArcusFrontCache(Cache cache) {
     this.cache = cache;


### PR DESCRIPTION
이름만으로 EhArcusFrontCache를 생성할 수 있도록 생성자를 추가하였습니다.

EhCache는 아래의 xml을 통해서 캐시 인스턴스를 생성하고 CacheManager에서 불러올 수 있습니다. EhArcusFrontCache에 cache name만 생성자로 전달하여, xml 속성값을 참조하고 캐시 인스턴스를 불러와 front cache 기능을 사용할 수 있도록 하였습니다.

```xml
<!-- ehcache.xml -->
<?xml version="1.0" encoding="UTF-8"?>
<ehcache
     maxBytesLocalHeap="1000">
    <defaultCache
      timeToIdleSeconds="120"
      timeToLiveSeconds="120"
      maxBytesLocalHeap="50%">
    </defaultCache>
  <cache
    name="test"
    timeToIdleSeconds="240"
    maxBytesLocalHeap="50%">
  </cache>
</ehcache>
```

==> 

```java
// timeToIdleSeconds=240, timeToLiveSeconds=0, maxBytesLocalHeap=500
new EhArcusFrontCache("test");          // ehcache.xml test cache 적용
 // timeToIdleSeconds=120, timeToLiveSeconds=120, maxBytesLocalHeap=500
new EhArcusFrontCache("noname");    // ehcache.xml의 defaultCache 적용

CacheManager newCacheManager = CacheManager.create("ehcache-newtest.xml");
new EhArcusFrontCache("newtest", newCacheManager);    //  ehcache-newtest.xml 적용
```

