### PR TITLE
FEATURE: Add abstract class ArcusKeyGenerator for more sensible usage of autowired KeyGenerator.

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusKeyGenerator.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusKeyGenerator.java
@@ -1,0 +1,11 @@
+package com.navercorp.arcus.spring.cache;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+
+public abstract class ArcusKeyGenerator implements KeyGenerator {
+  protected static final String DEFAULT_SEPARTOR = ",";
+
+  public Object generate(Object... params) {
+    return generate(null, null, params);
+  }
+}

--- a/src/main/java/com/navercorp/arcus/spring/cache/SimpleStringKeyGenerator.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/SimpleStringKeyGenerator.java
@@ -17,13 +17,9 @@
 
 package com.navercorp.arcus.spring.cache;
 
-import org.springframework.cache.interceptor.KeyGenerator;
-
 import java.lang.reflect.Method;
 
-public class SimpleStringKeyGenerator implements KeyGenerator {
-  private static final String DEFAULT_SEPARTOR = ",";
-
+public class SimpleStringKeyGenerator extends ArcusKeyGenerator {
   @Override
   public Object generate(Object target, Method method, Object... params) {
     StringBuilder keyBuilder = new StringBuilder();

--- a/src/main/java/com/navercorp/arcus/spring/cache/StringKeyGenerator.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/StringKeyGenerator.java
@@ -18,8 +18,6 @@
 
 package com.navercorp.arcus.spring.cache;
 
-import org.springframework.cache.interceptor.KeyGenerator;
-
 import java.lang.reflect.Method;
 
 /**
@@ -32,9 +30,7 @@ import java.lang.reflect.Method;
  * 기본적으로 메서드 매개변수를 조합해서 키 값을 생성합니다.
  * </p>
  */
-public class StringKeyGenerator implements KeyGenerator {
-  private static final String DEFAULT_SEPARTOR = ",";
-
+public class StringKeyGenerator extends ArcusKeyGenerator {
   @Override
   public Object generate(Object target, Method method, Object... params) {
     int hash = 0;

--- a/src/test/java/com/navercorp/arcus/spring/cache/KeyGeneratorTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/KeyGeneratorTest.java
@@ -18,29 +18,30 @@
 package com.navercorp.arcus.spring.cache;
 
 import org.junit.Test;
-import org.springframework.cache.interceptor.KeyGenerator;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 
 public class KeyGeneratorTest {
-  StringKeyGenerator stringKeyGenerator = new StringKeyGenerator();
-  SimpleStringKeyGenerator simpleStringKeyGenerator = new SimpleStringKeyGenerator();
+  ArcusKeyGenerator stringKeyGenerator = new StringKeyGenerator();
+  ArcusKeyGenerator simpleStringKeyGenerator = new SimpleStringKeyGenerator();
 
 
-  private void testGenExtract(KeyGenerator keyGenerator) throws Exception {
+  private void testGenExtract(ArcusKeyGenerator keyGenerator) throws Exception {
     StringBuilder longParam = new StringBuilder();
     for (int i = 0; i < 255; i++) {
       longParam.append(i);
     }
-    String key = ((ArcusStringKey) (keyGenerator.generate(null, null, longParam))).getStringKey();
+    String key = ((ArcusStringKey) (keyGenerator.generate(longParam))).getStringKey();
     assertThat(key.length() > 255, is(true));
     System.out.println(key);
   }
 
-  private void testGenDuplicatedKeysWithColons(KeyGenerator keyGenerator, boolean allowDupKey) {
-    ArcusStringKey arcusKey1 = (ArcusStringKey) keyGenerator.generate(null, null, "a,b", "c", "de");
-    ArcusStringKey arcusKey2 = (ArcusStringKey) keyGenerator.generate(null, null, "a,b", "c,de");
+  private void testGenDuplicatedKeysWithColons(ArcusKeyGenerator keyGenerator, boolean allowDupKey) {
+    ArcusStringKey arcusKey1 = (ArcusStringKey) keyGenerator.generate("a,b", "c", "de");
+    ArcusStringKey arcusKey2 = (ArcusStringKey) keyGenerator.generate("a,b", "c,de");
 
     if (allowDupKey) {
       assertEquals(arcusKey1.getStringKey(), arcusKey2.getStringKey());


### PR DESCRIPTION
- ArcusKeyGenerator 추상 클래스의 `generate(Object... params)` 메소드는 `generate(Object target, Method method, Object... params)` 메소드의 alias입니다. 
- SimpleStringKeyGenerator 클래스와 StringKeyGenerator 클래스에서 `Object target, Method method` 인자를 사용하지 않습니다.
- 응용에서 사용하지 않는 두 인자에 null을 넣게 되어 있는데, `generate(Object... params)` 메소드 그럴 필요가 없게 만들었습니다.