### PR TITLE
FEATURE: upgrade arcus-java-client version (1.13.2 => 1.13.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
         <org.slf4j.version>1.7.24</org.slf4j.version>
         <org.apache.logging.log4j.version>2.17.1</org.apache.logging.log4j.version>
-        <arcus.client.version>1.13.2</arcus.client.version>
+        <arcus.client.version>1.13.4</arcus.client.version>
         <junit.version>4.13.1</junit.version>
         <org.mockito.version>1.7</org.mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -69,7 +69,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.navercorp.arcus</groupId>
+            <groupId>com.jam2in.arcus</groupId>
             <artifactId>arcus-java-client</artifactId>
             <version>${arcus.client.version}</version>
             <exclusions>


### PR DESCRIPTION
arcus-java-client 의존성 버전을 1.13.4로 업그레이드하면서, naver maven repo가 아닌 jam2in maven repo를 사용하도록 변경했습니다.