### PR TITLE
INTERNAL: Add @Nullable annotation.

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/ArcusClientFactoryBean.java
+++ b/src/main/java/com/navercorp/arcus/spring/ArcusClientFactoryBean.java
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
+import javax.annotation.Nullable;
+
 public class ArcusClientFactoryBean implements FactoryBean<ArcusClientPool>,
         DisposableBean, InitializingBean {
 
@@ -67,7 +69,7 @@ public class ArcusClientFactoryBean implements FactoryBean<ArcusClientPool>,
     this.frontCacheCopyOnWrite = copyOnWrite;
   }
 
-  public void setGlobalTranscoder(Transcoder<Object> tc) {
+  public void setGlobalTranscoder(@Nullable Transcoder<Object> tc) {
     this.globalTranscoder = tc;
   }
 

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -31,6 +31,7 @@ import org.springframework.cache.support.SimpleValueWrapper;
 import org.springframework.util.Assert;
 import org.springframework.util.DigestUtils;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -101,6 +102,7 @@ public class ArcusCache implements Cache, InitializingBean {
     return this.arcusClient;
   }
 
+  @Nullable
   @Override
   public ValueWrapper get(Object key) {
     Object value = null;
@@ -116,6 +118,7 @@ public class ArcusCache implements Cache, InitializingBean {
   }
 
   @SuppressWarnings("unchecked")
+  @Nullable
   @Override
   public <T> T get(Object key, Class<T> type) {
     try {
@@ -132,6 +135,7 @@ public class ArcusCache implements Cache, InitializingBean {
   }
 
   @SuppressWarnings("unchecked")
+  @Nullable
   @Override
   public <T> T get(Object key, Callable<T> valueLoader) {
     String arcusKey = createArcusKey(key);
@@ -182,6 +186,7 @@ public class ArcusCache implements Cache, InitializingBean {
    * 수행되기 때문에 중간에 다른 캐시 연산 수행으로 인하여 새로운 값이 리턴 될 수 있으며 혹은 캐시 만료로 인해
    * ValueWrapper의 내부 value가 null이 되어 리턴될 수 있다.
    */
+  @Nullable
   @Override
   public ValueWrapper putIfAbsent(Object key, Object value) {
     String arcusKey = createArcusKey(key);
@@ -374,35 +379,39 @@ public class ArcusCache implements Cache, InitializingBean {
     return arcusClient;
   }
 
+  @Nullable
   public Transcoder<Object> getOperationTranscoder() {
     return operationTranscoder;
   }
 
-  public void setOperationTranscoder(Transcoder<Object> operationTranscoder) {
+  public void setOperationTranscoder(@Nullable Transcoder<Object> operationTranscoder) {
     this.operationTranscoder = operationTranscoder;
   }
 
+  @Nullable
   public String getPrefix() {
     return prefix;
   }
 
-  public void setPrefix(String prefix) {
+  public void setPrefix(@Nullable String prefix) {
     this.prefix = prefix;
   }
 
+  @Nullable
   public KeyLockProvider getKeyLockProvider() {
     return keyLockProvider;
   }
 
-  public void setKeyLockProvider(KeyLockProvider keyLockProvider) {
+  public void setKeyLockProvider(@Nullable KeyLockProvider keyLockProvider) {
     this.keyLockProvider = keyLockProvider;
   }
 
+  @Nullable
   public ArcusFrontCache getArcusFrontCache() {
     return arcusFrontCache;
   }
 
-  public void setArcusFrontCache(ArcusFrontCache arcusFrontCache) {
+  public void setArcusFrontCache(@Nullable ArcusFrontCache arcusFrontCache) {
     this.arcusFrontCache = arcusFrontCache;
   }
 
@@ -438,6 +447,7 @@ public class ArcusCache implements Cache, InitializingBean {
     }
   }
 
+  @Nullable
   private Object getValue(String arcusKey) throws Exception {
     logger.debug("getting value by key: {}", arcusKey);
 

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -22,6 +22,8 @@ import net.spy.memcached.transcoders.Transcoder;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
+import javax.annotation.Nullable;
+
 public class ArcusCacheConfiguration implements InitializingBean {
 
   private String serviceId;
@@ -41,11 +43,12 @@ public class ArcusCacheConfiguration implements InitializingBean {
     this.serviceId = serviceId;
   }
 
+  @Nullable
   public String getPrefix() {
     return prefix;
   }
 
-  public void setPrefix(String prefix) {
+  public void setPrefix(@Nullable String prefix) {
     this.prefix = prefix;
   }
 
@@ -73,19 +76,21 @@ public class ArcusCacheConfiguration implements InitializingBean {
     this.timeoutMilliSeconds = timeoutMilliSeconds;
   }
 
+  @Nullable
   public Transcoder<Object> getOperationTranscoder() {
     return operationTranscoder;
   }
 
-  public void setOperationTranscoder(Transcoder<Object> operationTranscoder) {
+  public void setOperationTranscoder(@Nullable Transcoder<Object> operationTranscoder) {
     this.operationTranscoder = operationTranscoder;
   }
 
+  @Nullable
   public ArcusFrontCache getArcusFrontCache() {
     return arcusFrontCache;
   }
 
-  public void setArcusFrontCache(ArcusFrontCache arcusFrontCache) {
+  public void setArcusFrontCache(@Nullable ArcusFrontCache arcusFrontCache) {
     this.arcusFrontCache = arcusFrontCache;
   }
 

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusStringKey.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusStringKey.java
@@ -17,6 +17,8 @@
 
 package com.navercorp.arcus.spring.cache;
 
+import javax.annotation.Nullable;
+
 public class ArcusStringKey {
   public static int light_hash(String str) {
     int hash = 7;
@@ -37,7 +39,7 @@ public class ArcusStringKey {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/navercorp/arcus/spring/cache/front/EhArcusFrontCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/front/EhArcusFrontCache.java
@@ -21,6 +21,8 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 
+import javax.annotation.Nullable;
+
 public class EhArcusFrontCache implements ArcusFrontCache {
 
   private final Cache cache;
@@ -44,6 +46,7 @@ public class EhArcusFrontCache implements ArcusFrontCache {
     this.cache = cache;
   }
 
+  @Nullable
   @Override
   public Object get(String key) {
     Element element = cache.get(key);
@@ -51,7 +54,7 @@ public class EhArcusFrontCache implements ArcusFrontCache {
   }
 
   @Override
-  public void set(String key, Object value, int expireTime) {
+  public void set(String key, @Nullable Object value, int expireTime) {
     Element element = new Element(key, value);
     element.setTimeToLive(expireTime);
     element.setTimeToIdle(0);


### PR DESCRIPTION
https://github.com/naver/arcus-spring/pull/61

위 PR의 후속 PR 입니다.
KeyGenerator 구현체 뿐만 아니라, `@Deprecated`가 붙지 않은 모든 클래스에 null 사용 가능 여부를 어노테이션으로 명시했습니다.

ArcusCache 클래스의 put 관련 메소드 중, putIfAbsent() 메소드에 한해 value에 `@NonNull`이 붙어 있는 것은 해당 메소드에서만 value가 null일 경우 Exception을 던지기 때문입니다.
다른 put 관련 메소드에서는 value에 대해 null 체크를 한 후 null이면 로그를 찍고 캐싱 로직을 수행하지 않습니다.