### PR TITLE
FEATURE: Add generateKey() method to KeyGenerator implementations.

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/SimpleStringKeyGenerator.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/SimpleStringKeyGenerator.java
@@ -19,15 +19,18 @@ package com.navercorp.arcus.spring.cache;
 
 import org.springframework.cache.interceptor.KeyGenerator;
 
-import java.lang.reflect.Method;
-
 import javax.annotation.Nullable;
+import java.lang.reflect.Method;
 
 public class SimpleStringKeyGenerator implements KeyGenerator {
   private static final String DEFAULT_SEPARATOR = ",";
 
   @Override
   public Object generate(@Nullable Object target, @Nullable Method method, Object... params) {
+    return generateKey(params);
+  }
+
+  public static ArcusStringKey generateKey(Object... params) {
     StringBuilder keyBuilder = new StringBuilder();
     for (int i = 0, n = params.length; i < n; i++) {
       if (i > 0) {

--- a/src/main/java/com/navercorp/arcus/spring/cache/StringKeyGenerator.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/StringKeyGenerator.java
@@ -20,9 +20,8 @@ package com.navercorp.arcus.spring.cache;
 
 import org.springframework.cache.interceptor.KeyGenerator;
 
-import java.lang.reflect.Method;
-
 import javax.annotation.Nullable;
+import java.lang.reflect.Method;
 
 /**
  * 스프링 Cache의 KeyGenerator 구현체.
@@ -39,6 +38,10 @@ public class StringKeyGenerator implements KeyGenerator {
 
   @Override
   public Object generate(@Nullable Object target, @Nullable Method method, Object... params) {
+    return generateKey(params);
+  }
+
+  public static ArcusStringKey generateKey(Object... params) {
     int hash = 0;
     StringBuilder keyBuilder = new StringBuilder();
     for (int i = 0, n = params.length; i < n; i++) {


### PR DESCRIPTION
https://github.com/naver/arcus-spring/issues/50

SimpleKeyGenerator와 같은 형태의 인터페이스를 하나 추가했습니다.
단, arcus-spring의 KeyGenerator 구현체에서 생성하는 객체는 명시적으로 ArcusStringKey 타입임을 나타내기 위해 반환 타입을 Object가 아닌 ArcusStringKey로 했습니다.