### PR TITLE
INTERNAL: Add constructor that is used by ArcusCacheManager to ArcusCache.

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -92,6 +92,26 @@ public class ArcusCache implements Cache, InitializingBean {
   private KeyLockProvider keyLockProvider = new DefaultKeyLockProvider();
   private ArcusFrontCache arcusFrontCache;
 
+  public ArcusCache() {
+
+  }
+
+  ArcusCache(String name, ArcusClientPool clientPool, ArcusCacheConfiguration configuration) {
+    this.name = name;
+    this.arcusClient = clientPool;
+    this.serviceId = configuration.getServiceId();
+    this.prefix = configuration.getPrefix();
+    this.expireSeconds = configuration.getExpireSeconds();
+    this.timeoutMilliSeconds = configuration.getTimeoutMilliSeconds();
+    this.operationTranscoder = configuration.getOperationTranscoder();
+    this.arcusFrontCache = configuration.getArcusFrontCache();
+    this.frontExpireSeconds = configuration.getFrontExpireSeconds();
+    this.forceFrontCaching = configuration.isForceFrontCaching();
+    this.wantToGetException = true;
+
+    this.afterPropertiesSet();
+  }
+
   @Override
   public String getName() {
     return this.name;
@@ -384,7 +404,7 @@ public class ArcusCache implements Cache, InitializingBean {
     return operationTranscoder;
   }
 
-  public void setOperationTranscoder(@Nullable Transcoder<Object> operationTranscoder) {
+  public void setOperationTranscoder(Transcoder<Object> operationTranscoder) {
     this.operationTranscoder = operationTranscoder;
   }
 
@@ -393,7 +413,7 @@ public class ArcusCache implements Cache, InitializingBean {
     return prefix;
   }
 
-  public void setPrefix(@Nullable String prefix) {
+  public void setPrefix(String prefix) {
     this.prefix = prefix;
   }
 
@@ -402,7 +422,7 @@ public class ArcusCache implements Cache, InitializingBean {
     return keyLockProvider;
   }
 
-  public void setKeyLockProvider(@Nullable KeyLockProvider keyLockProvider) {
+  public void setKeyLockProvider(KeyLockProvider keyLockProvider) {
     this.keyLockProvider = keyLockProvider;
   }
 
@@ -411,7 +431,7 @@ public class ArcusCache implements Cache, InitializingBean {
     return arcusFrontCache;
   }
 
-  public void setArcusFrontCache(@Nullable ArcusFrontCache arcusFrontCache) {
+  public void setArcusFrontCache(ArcusFrontCache arcusFrontCache) {
     this.arcusFrontCache = arcusFrontCache;
   }
 

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheManager.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheManager.java
@@ -108,22 +108,8 @@ public class ArcusCacheManager extends AbstractCacheManager implements Disposabl
    * @param configuration 생성할 캐시의 속성
    * @return 생성된 캐시
    */
-  @SuppressWarnings("deprecation")
   protected Cache createCache(String name, ArcusCacheConfiguration configuration) {
-    ArcusCache cache = new ArcusCache();
-    cache.setName(name);
-    cache.setServiceId(configuration.getServiceId());
-    cache.setPrefix(configuration.getPrefix());
-    cache.setArcusClient(client);
-    cache.setArcusFrontCache(configuration.getArcusFrontCache());
-    cache.setExpireSeconds(configuration.getExpireSeconds());
-    cache.setFrontExpireSeconds(configuration.getFrontExpireSeconds());
-    cache.setTimeoutMilliSeconds(configuration.getTimeoutMilliSeconds());
-    cache.setOperationTranscoder(configuration.getOperationTranscoder());
-    cache.setForceFrontCaching(configuration.isForceFrontCaching());
-    cache.setWantToGetException(true);
-
-    return cache;
+    return new ArcusCache(name, client, configuration);
   }
 
     @Override


### PR DESCRIPTION
ArcusCacheManager에서 사용하기 위한 용도의 생성자를 ArcusCache에 추가했습니다.
ArcusCache에 내부 동작과 인자가 없는 public 생성자를 추가한 이유는 별도의 생성자가 없는 경우에 내부 동작과 인자가 없는 public 생성자가 컴파일 과정에서 자동으로 생기는데, 이번에 default 접근 제한자를 갖는 생성자를 추가하여 내부 동작과 인자가 없는 public 생성자를 유지하기 위해서는 명시적으로 선언해야 하기 때문입니다