### PR TITLE
INTERNAL: get NullValue instance from arcus server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.13.5</version>
 
     <properties>
-        <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.10.RELEASE</org.springframework.version>
         <org.slf4j.version>1.7.24</org.slf4j.version>
         <org.apache.logging.log4j.version>2.17.1</org.apache.logging.log4j.version>
         <arcus.client.version>1.13.4</arcus.client.version>

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -36,6 +36,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
   private Transcoder<Object> operationTranscoder;
   private ArcusFrontCache arcusFrontCache;
   private boolean forceFrontCaching;
+  private boolean allowNullValues = ArcusCache.DEFAULT_ALLOW_NULL_VALUES;
 
   public String getServiceId() {
     return serviceId;
@@ -102,6 +103,14 @@ public class ArcusCacheConfiguration implements InitializingBean {
 
   public void setForceFrontCaching(boolean forceFrontCaching) {
     this.forceFrontCaching = forceFrontCaching;
+  }
+
+  public boolean isAllowNullValues() {
+    return this.allowNullValues;
+  }
+
+  public void setAllowNullValues(boolean allowNullValues) {
+    this.allowNullValues = allowNullValues;
   }
 
   @Override

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.cache.Cache;
+import org.springframework.cache.support.NullValue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -223,6 +224,22 @@ public class ArcusCacheTest {
     verify(arcusFrontCache, never())
         .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
     assertNull(value);
+  }
+
+  @Test
+  public void testGet_NullValue() {
+    // given
+    when(arcusClientPool.asyncGet(arcusKey))
+        .thenReturn(createGetFuture(NullValue.INSTANCE));
+
+    // when
+    Cache.ValueWrapper value = arcusCache.get(ARCUS_STRING_KEY);
+
+    // then
+    verify(arcusClientPool, times(1))
+        .asyncGet(arcusKey);
+    assertNotNull(value);
+    assertNull(value.get());
   }
 
   @Test


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/541

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ArcusCache 클래스가 AbstractValueAdaptingCache 클래스를 상속받도록 변경합니다. 이를 위해 lookup 메서드를 재정의했습니다.
- 이를 통해 ArcusCache 클래스에서 기본적으로 AbstractValueAdaptingCache 클래스의 get 메서드가 사용됩니다. 그리고 이 때 NullValue 객체 조회 시 null을 반환해주게 됩니다.
- ArcusCacheConfiguration 클래스에서는 cacheNullValues 속성을 설정할 수 있도록 합니다.
- 기존에 `get(Object key)` 메서드에서는 wantToGetException 속성이 유효했지만, 현재는 해당 설정이 무효하여 예외가 발생하면 그대로 전파됩니다.