### PR TITLE
FIX: Set default value of wantToGetException to false and fix inconsistent exception handling.

### DIFF
--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerTest.java
@@ -45,7 +45,7 @@ public class ArcusCacheManagerTest {
   private static final String SERVICE_PREFIX = "test-prefix";
   private static final int TIMEOUT_MILLIS = 100;
   private static final int DEFAULT_EXPIRE_SECONDS = 1;
-  private static final boolean WANT_TO_GET_EXCEPTION = true;
+  private static final boolean WANT_TO_GET_EXCEPTION = false;
   private static final String PRE_DEFINED_CACHE_NAME = "pre-defined-cache";
   private static final int PRE_DEFINED_EXPIRE_SECONDS = 2;
 

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
@@ -759,8 +759,10 @@ public class ArcusCacheTest {
   }
 
   @Test(expected = TestException.class)
+  @SuppressWarnings("deprecation")
   public void testGetType_Exception() {
     // given
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenThrow(new TestException());
 
@@ -769,8 +771,10 @@ public class ArcusCacheTest {
   }
 
   @Test(expected = TestException.class)
+  @SuppressWarnings("deprecation")
   public void testGetType_FutureException() {
     // given
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenReturn(createGetFutureException());
 
@@ -862,10 +866,12 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testGetValueLoader_Get_Exception() throws Exception {
     // given
     TestException exception = null;
     arcusCache.setKeyLockProvider(keyLockProvider);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenThrow(new TestException());
     when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
@@ -894,10 +900,12 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testGetValueLoader_Get_FutureException() throws Exception {
     // given
     TestException exception = null;
     arcusCache.setKeyLockProvider(keyLockProvider);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenReturn(createGetFutureException());
     when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
@@ -926,10 +934,12 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testGetValueLoader_Get_SecondException() throws Exception {
     // given
     TestException exception = null;
     arcusCache.setKeyLockProvider(keyLockProvider);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenReturn(createGetFuture(null))
         .thenThrow(new TestException());
@@ -959,10 +969,12 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testGetValueLoader_Get_SecondFutureException() throws Exception {
     // given
     TestException exception = null;
     arcusCache.setKeyLockProvider(keyLockProvider);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenReturn(createGetFuture(null))
         .thenReturn(createGetFutureException());
@@ -992,11 +1004,13 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testGetValueLoader_Put_Exception() throws Exception {
     // given
     TestException exception = null;
     arcusCache.setExpireSeconds(EXPIRE_SECONDS);
     arcusCache.setKeyLockProvider(keyLockProvider);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenReturn(createGetFuture(null));
     when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
@@ -1025,11 +1039,13 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testGetValueLoader_Put_FutureException() throws Exception {
     // given
     TestException exception = null;
     arcusCache.setExpireSeconds(EXPIRE_SECONDS);
     arcusCache.setKeyLockProvider(keyLockProvider);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.asyncGet(arcusKey))
         .thenReturn(createGetFuture(null));
     when(arcusClientPool.set(arcusKey, EXPIRE_SECONDS, VALUE))
@@ -1214,12 +1230,14 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testPutIfAbsent_FrontCache_Exception() {
      // given
     TestException exception = null;
     arcusCache.setArcusFrontCache(arcusFrontCache);
     arcusCache.setExpireSeconds(EXPIRE_SECONDS);
     arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
         .thenThrow(new TestException());
     when(arcusClientPool.asyncGet(arcusKey))
@@ -1249,12 +1267,14 @@ public class ArcusCacheTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testPutIfAbsent_FrontCache_FutureException() {
      // given
     TestException exception = null;
     arcusCache.setArcusFrontCache(arcusFrontCache);
     arcusCache.setExpireSeconds(EXPIRE_SECONDS);
     arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
+    arcusCache.setWantToGetException(true);
     when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
         .thenReturn(createOperationFutureException());
     when(arcusClientPool.asyncGet(arcusKey))


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/564

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 주간회의에서 논의한 대로 wantToGetException의 기본값을 false로 설정하고, 캐시 연산 시 항상 wantToGetException을 사용합니다.
- 일부 테스트 코드가 wantToGetException의 기본값이 true인 경우를 상정하고 만들어져 있어서 해당 테스트 코드 수행 전에 wantToGetException을 true로 설정합니다.
