### PR TITLE
INTERNAL: Change default value of wantToGetException from literal to static final constant.

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -81,7 +81,8 @@ import org.springframework.util.DigestUtils;
 public class ArcusCache extends AbstractValueAdaptingCache implements InitializingBean {
 
   public static final long DEFAULT_TIMEOUT_MILLISECONDS = 700L;
-
+  @Deprecated
+  public static final boolean DEFAULT_WANT_TO_GET_EXCEPTION = false;
   public static final boolean DEFAULT_ALLOW_NULL_VALUES = true;
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -94,7 +95,7 @@ public class ArcusCache extends AbstractValueAdaptingCache implements Initializi
   private long timeoutMilliSeconds = DEFAULT_TIMEOUT_MILLISECONDS;
   private ArcusClientPool arcusClient;
   @Deprecated
-  private boolean wantToGetException = false;
+  private boolean wantToGetException = DEFAULT_WANT_TO_GET_EXCEPTION;
   private boolean forceFrontCaching;
   private Transcoder<Object> operationTranscoder;
   private KeyLockProvider keyLockProvider = new DefaultKeyLockProvider();

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -37,7 +37,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
   private Transcoder<Object> operationTranscoder;
   private ArcusFrontCache arcusFrontCache;
   @Deprecated
-  private boolean wantToGetException = false;
+  private boolean wantToGetException = ArcusCache.DEFAULT_WANT_TO_GET_EXCEPTION;
   private boolean forceFrontCaching;
   private boolean allowNullValues = ArcusCache.DEFAULT_ALLOW_NULL_VALUES;
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 동일한 의미를 갖는 필드의 기본값을 리터럴로 관리할 경우, 한 쪽만 값을 변경했을 때 다른 쪽의 값이 달라 문제가 될 수 있다.
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- wantToGetException 필드의 기본값을 static final로 선언하고 이를 사용하게 합니다.
- wantToGetException 필드가 계속 유지될지 말지에 관계 없이, 적어도 유지되는 동안에는 기본값을 바꾸었을 때의 휴먼 에러를 줄이기 위한 커밋입니다.
