### PR TITLE
INTERNAL: put NullValue instance to Arcus and frontCache

### DIFF
--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheIntegrationTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheIntegrationTest.java
@@ -42,6 +42,9 @@ public class ArcusCacheIntegrationTest {
   @Autowired
   private ArcusCache arcusCache;
 
+  @Autowired
+  private ArcusCache arcusCacheWithoutAllowingNullValue;
+
   @After
   public void tearDown() {
     arcusCache.evict(TEST_KEY);
@@ -152,11 +155,18 @@ public class ArcusCacheIntegrationTest {
   }
 
   @Test
-  public void putTheNullValue() {
+  public void putTheNullValueIfAllowNullValuesIsTrue() {
+
     arcusCache.put(TEST_KEY, null);
 
-    Object result = arcusCache.get(TEST_KEY);
-    assertNull(result);
+    Cache.ValueWrapper result = arcusCache.get(TEST_KEY);
+    assertNotNull(result);
+    assertNull(result.get());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void putTheNullValueIfAllowNullValuesIsFalse() {
+    arcusCacheWithoutAllowingNullValue.put(TEST_KEY, null);
   }
 
   @Test

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
@@ -1300,10 +1300,8 @@ public class ArcusCacheTest {
     arcusCache.setExpireSeconds(EXPIRE_SECONDS);
     arcusCache.setFrontExpireSeconds(FRONT_EXPIRE_SECONDS);
     arcusCache.setWantToGetException(true);
-    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, VALUE))
-        .thenReturn(createOperationFuture(true));
-    when(arcusClientPool.asyncGet(arcusKey))
-        .thenReturn(createGetFuture(VALUE));
+    when(arcusClientPool.add(arcusKey, EXPIRE_SECONDS, NullValue.INSTANCE))
+            .thenReturn(createOperationFuture(true));
 
     // when
     try {
@@ -1313,12 +1311,12 @@ public class ArcusCacheTest {
     }
 
     // then
-    verify(arcusClientPool, never())
-        .add(arcusKey, EXPIRE_SECONDS, VALUE);
     verify(arcusClientPool, times(1))
-        .asyncGet(arcusKey);
+            .add(arcusKey, EXPIRE_SECONDS, NullValue.INSTANCE);
     verify(arcusFrontCache, times(1))
-        .set(arcusKey, VALUE, FRONT_EXPIRE_SECONDS);
+            .set(arcusKey, NullValue.INSTANCE, FRONT_EXPIRE_SECONDS);
+    verify(arcusClientPool, never())
+            .asyncGet(arcusKey);
     assertNull(exception);
   }
 

--- a/src/test/resources/arcus_spring_arcusCache_test.xml
+++ b/src/test/resources/arcus_spring_arcusCache_test.xml
@@ -21,4 +21,17 @@
           p:expireSeconds="3000"
           p:serviceId="testService-"
           p:prefix="testPrefix"/>
+
+    <bean id="arcusCacheConfiguration" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"
+          p:allowNullValues="false"
+          p:timeoutMilliSeconds="500"
+          p:expireSeconds="3000"
+          p:serviceId="testService-"
+          p:prefix="testService-"/>
+
+    <bean id="arcusCacheWithoutAllowingNullValue" class="com.navercorp.arcus.spring.cache.ArcusCache">
+        <constructor-arg name="name" value="arcusCache"/>
+        <constructor-arg name="clientPool" ref="arcusClient"/>
+        <constructor-arg name="configuration" ref="arcusCacheConfiguration"/>
+    </bean>
 </beans>


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/541

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- put, putIfAbsent에서 NullValue를 저장하는 기능을 추가합니다.
- `getSynchrinozed(...)`에서 기존에는 createArcusKey의 결과인 String을 사용해 lock을 잡고 loadValue에도 넘겨 사용했었는데, 이런 방식으로는 같은 클래스의 public 메서드인 put을 사용할 수 없어 putValue를 직접 사용해야만 했습니다. 따라서 createArcusKey를 put 메서드 내부에서만 호출하게 하고 나머지 부분에서는 key를 그대로 사용하도록 하여 메서드 로직을 간결하게 만들었습니다.
- `putIfAbsent(...)` 에서 arcus java client API를 사용하는 부분을 따로 메서드로 분리했습니다.
