### PR TITLE
REFACTOR: use put method when get synchronized

### DIFF
--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheTest.java
@@ -789,7 +789,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFuture(true));
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -817,7 +817,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFutureException());
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -845,7 +845,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFuture(true));
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -941,7 +941,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFuture(true));
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -975,7 +975,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFuture(true));
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -1009,7 +1009,7 @@ public class ArcusCacheTest {
         .thenThrow(new TestException());
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -1043,7 +1043,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFutureException());
     when(valueLoader.call())
         .thenReturn(VALUE);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -1075,7 +1075,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFuture(true));
     when(valueLoader.call())
         .thenReturn(null);
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);
@@ -1103,7 +1103,7 @@ public class ArcusCacheTest {
         .thenReturn(createOperationFuture(true));
     when(valueLoader.call())
         .thenThrow(new TestException());
-    when(keyLockProvider.getLockForKey(arcusKey))
+    when(keyLockProvider.getLockForKey(ARCUS_STRING_KEY))
         .thenReturn(readWriteLock);
     when(readWriteLock.writeLock())
         .thenReturn(lock);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- get synchronized 시에 호출되는 putValue 메서드를 put 메서드로 변경하여 중복되는 키 생성, 예외 잡는 코드를 줄입니다.
- 이로 인해 Lock의 대상 객체를 String key에서 Object key로 변경하였습니다.
