### PR TITLE
INTERNAL: add builder and transaction for ArcusCacheManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,24 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <!-- Exclude Commons Logging in favor of SLF4j -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
             <scope>test</scope>

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerBuilderTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerBuilderTest.java
@@ -1,0 +1,75 @@
+package com.navercorp.arcus.spring.cache;
+
+import java.util.Collections;
+
+import net.spy.memcached.ArcusClient;
+import net.spy.memcached.ArcusClientPool;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ArcusCacheManagerBuilderTest {
+
+  private final ArcusClientPool arcusClientPool = ArcusClient.createArcusClientPool("localhost:2181", "test", 4);
+
+  @Test
+  void testMissingCacheMadeByDefaultCacheConfig() {
+    ArcusCacheConfiguration configuration = new ArcusCacheConfiguration();
+    configuration.setServiceId("TEST-");
+    ArcusCacheManager cm = ArcusCacheManager.builder(arcusClientPool).cacheDefaults(configuration).build();
+    cm.afterPropertiesSet();
+
+    ArcusCache missingCache = (ArcusCache) cm.getMissingCache("new-cache");
+    assertNotNull(missingCache);
+    assertEquals(configuration.getServiceId(), missingCache.getServiceId());
+    assertEquals(configuration.getPrefix(), missingCache.getPrefix());
+    assertEquals(configuration.getExpireSeconds(), missingCache.getExpireSeconds());
+  }
+
+  @Test
+  void testSettingDifferentDefaultCacheConfiguration() {
+    ArcusCacheConfiguration withPrefix = new ArcusCacheConfiguration();
+    withPrefix.setPrefix("prefix");
+    ArcusCacheConfiguration withoutPrefix = new ArcusCacheConfiguration();
+
+    ArcusCacheManager cm = ArcusCacheManager.builder(arcusClientPool)
+            .cacheDefaults(withPrefix)
+            .initialCacheNames(Collections.singleton("first-cache"))
+            .cacheDefaults(withoutPrefix)
+            .initialCacheNames(Collections.singleton("second-cache"))
+            .build();
+
+    cm.afterPropertiesSet();
+
+    ArcusCache firstCache = (ArcusCache) cm.getCache("first-cache");
+    assertNotNull(firstCache);
+    assertEquals(withPrefix.getPrefix(), firstCache.getPrefix());
+    ArcusCache secondCache = (ArcusCache) cm.getCache("second-cache");
+    assertNotNull(secondCache);
+    assertNull(withoutPrefix.getPrefix());
+    assertEquals(withoutPrefix.getPrefix(), secondCache.getPrefix());
+  }
+
+  @Test
+  void testTransactionAwareCacheManager() {
+    Cache cache = ArcusCacheManager.builder(arcusClientPool)
+            .transactionAware()
+            .build()
+            .getCache("decorated-cache");
+
+    assertInstanceOf(TransactionAwareCacheDecorator.class, cache);
+  }
+
+  @Test
+  void testArcusClientNull() {
+    assertThrows(IllegalStateException.class, () -> ArcusCacheManager.builder(null).build());
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/601

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 현재 대부분의 CacheManager 구현체가 상속받고 있는 AbstractTransactionSupportingCacheManager를 상속받도록 변경했습니다. 이에 따라 spring-context-support, spring-tx 의존성이 추가되었습니다.
- CacheManager 빌더를 추가했습니다.
- ArcusCacheConfiguration에 default config를 얻을 수 있는 메서드를 추가했습니다. 이를 통해 빌더를 사용하면 반드시 default config를 입력하지 않아도 됩니다.