### PR TITLE
INTERNAL: set empty string as serviceId's default value

### DIFF
--- a/docs/02-arcus-spring-concept.md
+++ b/docs/02-arcus-spring-concept.md
@@ -62,13 +62,12 @@ ArcusCache 객체를 생성하기 위해 사용되는 캐시 설정 클래스이
 
 - `String serviceId`
   - 다음에 설명할 prefix와 조합하여 캐시 키의 Prefix를 생성하는 데 사용된다.
-  - 주로 배포 단계(test, dev, stage, prod, ...)를 구분하기 위한 문자열을 지정한다.
-  - null이 아닌 값을 필수적으로 지정해야 한다.
+  - 배포 단계(test, dev, stage, prod, ...)를 구분하기 위한 문자열을 지정한다.
   - [1장의 Cache Key 설명](01-arcus-cache-basics.md#cache-key)을 참고하여 ARCUS Cache의 캐시 키로 사용할 수 없는 문자열이 포함되지 않도록 해야 한다.
 - `String prefix`
   - serviceId와 조합하여 캐시 키의 Prefix를 생성하는 데 사용된다.
   - 주로 ARCUS Cache에 저장할 객체의 종류(Product, User, Order, ...)를 나타내는 문자열을 지정한다.
-  - 필수적으로 지정하지 않아도 되며, null을 지정할 수 있다. 이 경우 캐시 키의 Prefix를 생성할 때 serviceId와 현재 캐시 설정으로 생성하는 ArcusCache 객체의 캐시 이름이 사용된다. 
+  - 필수적으로 지정하지 않아도 되며, 이 경우 캐시 키의 Prefix를 생성할 때 serviceId와 현재 캐시 설정으로 생성하는 ArcusCache 객체의 캐시 이름이 사용된다. 
   - null이 아닌 값을 지정하는 경우, [1장의 Cache Key 설명](01-arcus-cache-basics.md#cache-key)을 참고하여 ARCUS Cache의 캐시 키로 사용할 수 없는 문자열이 포함되지 않도록 해야 한다.
 - `int expireSeconds`
   - 캐시 아이템의 Expire Time을 Seconds 단위로 지정한다.

--- a/docs/03-arcus-spring-usage.md
+++ b/docs/03-arcus-spring-usage.md
@@ -87,11 +87,7 @@ Spring Cache Abstraction을 통해 ARCUS Cache를 사용하려면, 다음과 같
         </constructor-arg>
     </bean>
 
-    <bean id="defaultCacheConfig" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration">
-        <property name="serviceId" value=""/>
-        <property name="expireSeconds" value="240"/>
-        <property name="timeoutMilliSeconds" value="800"/>
-    </bean>
+    <bean id="defaultCacheConfig" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"/>
 
 </beans>
 ```
@@ -130,11 +126,7 @@ public class ArcusConfiguration extends CachingConfigurerSupport {
 
   @Bean
   public ArcusCacheConfiguration defaultCacheConfig() {
-    ArcusCacheConfiguration defaultCacheConfig = new ArcusCacheConfiguration();
-    defaultCacheConfig.setServiceId("");
-    defaultCacheConfig.setExpireSeconds(240);
-    defaultCacheConfig.setTimeoutMilliSeconds(800);
-    return defaultCacheConfig;
+    return new ArcusCacheConfiguration();
   }
 
   @Bean

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -44,9 +44,9 @@ import org.springframework.util.DigestUtils;
 /**
  * 스프링 Cache의 Arcus 구현체.
  * <p>
- * Arcus의 key 구조는 prefix:subkey 입니다. prefix는 사용자가 그룹으로 생성하고자 하는 subkey들의 집합이며
- * ArcusCache에서는 서비스 또는 빌드 단계 등의 구분을 위해 serviceId + name으로 정의합니다. serviceCode
- * 속성과 name는 반드시 설정되어야 합니다.
+ * Arcus 캐시 키의 기본 구조는 prefix:subkey 입니다. prefix는 사용자가 그룹으로 생성하고자 하는 subkey들의 집합이며
+ * ArcusCache에서는 서비스 또는 빌드 단계 등의 구분을 위해 serviceId + <prefix | name> 문자열을 캐시 키의 prefix로 정의합니다.
+ *
  * </p>
  * <pre>{@code
  * <bean id="operationTranscoderA" class="net.spy.memcached.transcoders.SerializingTranscoder">
@@ -87,8 +87,8 @@ public class ArcusCache extends AbstractValueAdaptingCache implements Initializi
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private String name;
+  private String serviceId = "";
   private String prefix;
-  private String serviceId;
   private int expireSeconds;
   private int frontExpireSeconds;
   private long timeoutMilliSeconds = DEFAULT_TIMEOUT_MILLISECONDS;
@@ -339,7 +339,6 @@ public class ArcusCache extends AbstractValueAdaptingCache implements Initializi
     if (name == null && prefix == null) {
       throw new IllegalArgumentException("ArcusCache's 'name' or 'prefix' property must have a value.");
     }
-    Assert.notNull(serviceId, "ArcusCache's serviceId property must have a value.");
   }
 
   public String getServiceId() {
@@ -347,6 +346,7 @@ public class ArcusCache extends AbstractValueAdaptingCache implements Initializi
   }
 
   public void setServiceId(String serviceId) {
+    Assert.notNull(serviceId, "ArcusCache's serviceId property must have a value.");
     this.serviceId = serviceId;
   }
 

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
 @SuppressWarnings("DeprecatedIsStillUsed")
 public class ArcusCacheConfiguration implements InitializingBean {
 
-  private String serviceId;
+  private String serviceId = "";
   private String prefix;
   private int expireSeconds;
   private int frontExpireSeconds;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-spring/pull/98 에서 파생된 PR입니다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- serviceId 값을 사용하지 않을 때 빈 문자열`""`를 지정하는데, 이를 기본값으로 두도록 합니다.
- 이를 통해 DefaultCacheConfiguration을 사용자가 지정할 때 new ArcusCacheConfiguration() 만 호출해도 이미 세팅된 기본값으로 동작할 수 있습니다. 기존에는 configuration의 setServiceId를 통해 반드시 빈 문자열을 지정해줘야만 ArcusCache가 빈으로 등록되었습니다.
