### PR TITLE
 INTERNAL: save configuration instance in ArcusCache

### DIFF
--- a/src/test/java/com/navercorp/arcus/spring/ApplicationContextLoadTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/ApplicationContextLoadTest.java
@@ -48,12 +48,12 @@ public class ApplicationContextLoadTest {
 
     ArcusClientPool client = context.getBean(ArcusClientPool.class);
     CacheManager cacheManager = context.getBean(CacheManager.class);
-    Cache Cache = cacheManager.getCache("testCache");
+    Cache cache = cacheManager.getCache("testCache");
 
     assertNotNull(client);
     assertNotNull(cacheManager);
-    assertInstanceOf(ArcusCache.class, Cache);
-    assertSame(((ArcusCache) Cache).getArcusClient(), client);
+    assertInstanceOf(ArcusCache.class, cache);
+    assertSame(cache.getNativeCache(), client);
   }
 
 }

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerBuilderTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerBuilderTest.java
@@ -29,9 +29,9 @@ class ArcusCacheManagerBuilderTest {
 
     ArcusCache missingCache = (ArcusCache) cm.getMissingCache("new-cache");
     assertNotNull(missingCache);
-    assertEquals(configuration.getServiceId(), missingCache.getServiceId());
-    assertEquals(configuration.getPrefix(), missingCache.getPrefix());
-    assertEquals(configuration.getExpireSeconds(), missingCache.getExpireSeconds());
+    assertEquals(configuration.getServiceId(), missingCache.getCacheConfiguration().getServiceId());
+    assertEquals(configuration.getPrefix(), missingCache.getCacheConfiguration().getPrefix());
+    assertEquals(configuration.getExpireSeconds(), missingCache.getCacheConfiguration().getExpireSeconds());
   }
 
   @Test
@@ -51,11 +51,11 @@ class ArcusCacheManagerBuilderTest {
 
     ArcusCache firstCache = (ArcusCache) cm.getCache("first-cache");
     assertNotNull(firstCache);
-    assertEquals(withPrefix.getPrefix(), firstCache.getPrefix());
+    assertEquals(withPrefix.getPrefix(), firstCache.getCacheConfiguration().getPrefix());
     ArcusCache secondCache = (ArcusCache) cm.getCache("second-cache");
     assertNotNull(secondCache);
     assertNull(withoutPrefix.getPrefix());
-    assertEquals(withoutPrefix.getPrefix(), secondCache.getPrefix());
+    assertEquals(withoutPrefix.getPrefix(), secondCache.getCacheConfiguration().getPrefix());
   }
 
   @Test

--- a/src/test/resources/arcus_spring_arcusCache_annotation_test.xml
+++ b/src/test/resources/arcus_spring_arcusCache_annotation_test.xml
@@ -18,17 +18,20 @@
           p:url="#{arcusConfig['url']}"
           p:serviceCode="#{arcusConfig['serviceCode']}"
           p:poolSize="4"/>
+    <bean id="arcusCacheConfiguration" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"
+          p:timeoutMilliSeconds="500"
+          p:expireSeconds="3000"
+          p:serviceId="testService-"
+          p:prefix="testPrefix"/>
 
     <bean id="arcusCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
         <property name="caches">
             <list>
-                <bean id="arcusCache" class="com.navercorp.arcus.spring.cache.ArcusCache"
-                      p:name="arcusCache"
-                      p:arcusClient-ref="arcusClient"
-                      p:timeoutMilliSeconds="500"
-                      p:expireSeconds="3000"
-                      p:serviceId="testService-"
-                      p:prefix="testPrefix"/>
+                <bean id="arcusCache" class="com.navercorp.arcus.spring.cache.ArcusCache">
+                    <constructor-arg value="arcusCache"/>
+                    <constructor-arg ref="arcusClient"/>
+                    <constructor-arg ref="arcusCacheConfiguration"/>
+                </bean>
             </list>
         </property>
     </bean>

--- a/src/test/resources/arcus_spring_arcusCache_test.xml
+++ b/src/test/resources/arcus_spring_arcusCache_test.xml
@@ -14,24 +14,28 @@
           p:serviceCode="#{arcusConfig['serviceCode']}"
           p:poolSize="4"/>
 
-    <bean id="arcusCache" class="com.navercorp.arcus.spring.cache.ArcusCache"
-          p:name="arcusCache"
-          p:arcusClient-ref="arcusClient"
+    <bean id="arcusCacheConfiguration" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"
           p:timeoutMilliSeconds="500"
           p:expireSeconds="3000"
           p:serviceId="testService-"
           p:prefix="testPrefix"/>
 
-    <bean id="arcusCacheConfiguration" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"
+    <bean id="arcusCache" class="com.navercorp.arcus.spring.cache.ArcusCache">
+        <constructor-arg name="name" value="arcusCache"/>
+        <constructor-arg name="clientPool" ref="arcusClient"/>
+        <constructor-arg name="configuration" ref="arcusCacheConfiguration"/>
+    </bean>
+
+    <bean id="configWithoutAllowingNullValue" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"
           p:allowNullValues="false"
           p:timeoutMilliSeconds="500"
           p:expireSeconds="3000"
           p:serviceId="testService-"
-          p:prefix="testService-"/>
+          p:prefix="testPrefix"/>
 
     <bean id="arcusCacheWithoutAllowingNullValue" class="com.navercorp.arcus.spring.cache.ArcusCache">
         <constructor-arg name="name" value="arcusCache"/>
         <constructor-arg name="clientPool" ref="arcusClient"/>
-        <constructor-arg name="configuration" ref="arcusCacheConfiguration"/>
+        <constructor-arg name="configuration" ref="configWithoutAllowingNullValue"/>
     </bean>
 </beans>

--- a/src/test/resources/arcus_spring_basic_context_test.xml
+++ b/src/test/resources/arcus_spring_basic_context_test.xml
@@ -14,13 +14,16 @@
           p:serviceCode="#{arcusConfig['serviceCode']}"
           p:poolSize="4"/>
 
-    <bean id="arcusCache" class="com.navercorp.arcus.spring.cache.ArcusCache"
-          p:arcusClient-ref="arcusClient"
+    <bean id="arcusCacheConfiguration" class="com.navercorp.arcus.spring.cache.ArcusCacheConfiguration"
           p:timeoutMilliSeconds="500"
           p:expireSeconds="3000"
           p:serviceId="testService-"
-          p:prefix="testPrefix"
-          abstract="true"/>
+          p:prefix="testPrefix"/>
+    <bean id="arcusCache" class="com.navercorp.arcus.spring.cache.ArcusCache" abstract="true">
+        <constructor-arg value="arcusCache"/>
+        <constructor-arg ref="arcusClient"/>
+        <constructor-arg ref="arcusCacheConfiguration"/>
+    </bean>
 
     <bean id="arcusCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
         <property name="caches">


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-spring/issues/65

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 인자가 없는 생성자를 deprecate 시켜 사용하지 않도록 권장합니다. 대신 필수 인자를 입력해야 하는 생성자를 제공합니다.
- 반드시 내부에서만 사용되어야 하는 필드인 keyLockProvider를 제외하고는 모두 configuration을 통해 접근하도록 변경했습니다.
- 이를 통해 필수 인자가 아닌 옵션들의 검증은 ArcusConfiguration 한 군데에서만 거치면 됩니다. setter, getter도 ArcusCache 클래스에서 제공해줄 필요가 없습니다.
- 참고로 redis, couchbase도 XXXCache 클래스에 XXXCacheConfiguration 클래스를 필드로 두고 있습니다.
