### PR TITLE
INTERNAL: provide meaningful methods instead of setters in ArcusCacheConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,10 @@ public class ArcusConfiguration extends CachingConfigurerSupport {
 
     @Bean
     public ArcusCacheConfiguration defaultCacheConfig() {
-        ArcusCacheConfiguration defaultCacheConfig = new ArcusCacheConfiguration();
-        defaultCacheConfig.setPrefix("DEFAULT");
-        defaultCacheConfig.setExpireSeconds(60);
-        defaultCacheConfig.setTimeoutMilliSeconds(800);
-        return defaultCacheConfig;
+        return new ArcusCacheConfiguration()
+            .withPrefix("DEFAULT")
+            .withExpireSeconds(60)
+            .withTimeoutMilliSeconds(800);
     }
 
     @Bean
@@ -168,22 +167,20 @@ public class ArcusConfiguration extends CachingConfigurerSupport {
 
     @Bean
     public ArcusCacheConfiguration testCacheConfig() {
-        ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-        cacheConfig.setServiceId("TEST-");
-        cacheConfig.setPrefix("PRODUCT");
-        cacheConfig.setExpireSeconds(60);
-        cacheConfig.setTimeoutMilliSeconds(800);
-        return cacheConfig;
+        return new ArcusCacheConfiguration()
+            .withServiceId("TEST-")
+            .withPrefix("PRODUCT")
+            .withExpireSeconds(60)
+            .withTimeoutMillisSeconds(800);
     }
 
     @Bean
     public ArcusCacheConfiguration devCacheConfig() {
-        ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-        cacheConfig.setServiceId("DEV-");
-        cacheConfig.setPrefix("PRODUCT");
-        cacheConfig.setExpireSeconds(120);
-        cacheConfig.setTimeoutMilliSeconds(800);
-        return cacheConfig;
+        return new ArcusCacheConfiguration()
+            .withServiceId("DEV-")
+            .withPrefix("PRODUCT")
+            .withExpireSeconds(120)
+            .withTimeoutMillisSeconds(800);
     }
 
 }
@@ -234,32 +231,30 @@ You can use the front cache to provide fast responsiveness of cache requests. Th
 ```java
 @Bean
 public ArcusCacheConfiguration testCacheConfig() {
-    ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-    cacheConfig.setServiceId("TEST-");
-    cacheConfig.setPrefix("PRODUCT");
-    cacheConfig.setExpireSeconds(60);
-    cacheConfig.setTimeoutMilliSeconds(800);
-    /* front cache configuration */
-    cacheConfig.setArcusFrontCache(testArcusFrontCache());
-    cacheConfig.setFrontExpireSeconds(120);
-    cacheConfig.setForceFrontCaching(false);
-    /* front cache configuration */
-    return cacheConfig;
+  return new ArcusCacheConfiguration()
+      .withServiceId("TEST-")
+      .withPrefix("PRODUCT")
+      .withExpireSeconds(60)
+      .withTimeoutMilliSeconds(800)
+      /* front cache configuration */
+      .withArcusFrontCache(testArcusFrontCache())
+      .withFrontExpireSeconds(120)
+      .enableForcingFrontCache();
+      /* front cache configuration */
 }
 
 @Bean
 public ArcusCacheConfiguration devCacheConfig() {
-    ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-    cacheConfig.setServiceId("DEV-");
-    cacheConfig.setPrefix("PRODUCT");
-    cacheConfig.setExpireSeconds(120);
-    cacheConfig.setTimeoutMilliSeconds(800);
-    /* front cache configuration */
-    cacheConfig.setArcusFrontCache(devArcusFrontCache());
-    cacheConfig.setFrontExpireSeconds(240);
-    cacheConfig.setForceFrontCaching(true);
-    /* front cache configuration */
-    return cacheConfig;
+  return new ArcusCacheConfiguration()
+      .withServiceId("DEV-")
+      .withPrefix("PRODUCT")
+      .withExpireSeconds(120)
+      .withTimeoutMilliSeconds(800)
+      /* front cache configuration */
+      .withArcusFrontCache(devArcusFrontCache())
+      .withFrontExpireSeconds(240)
+      .enableForcingFrontCache();
+      /* front cache configuration */
 }
 
 @Bean
@@ -273,16 +268,19 @@ public ArcusFrontCache devArcusFrontCache() {
 }
 ```
 
-The properties added to the `ArcusCache` class related to Front Cache are as follows.
+The properties added to the `ArcusCacheConfiguration` class related to Front Cache are as follows.
 
-- `setArcusFrontCache(ArcusFrontCache arcusFrontCache)`
-  - Front Cache instance setting. If it is a null value, Front Cache does not work.
-- `setFrontExpireSeconds(int frontExpireSeconds)`
-  - Front Cache TTL(TimeToLive) setting.
-- `setForceFrontCaching(int forceFrontCaching)`
-  - true: Even if the change request of ARCUS fails, the change request is reflected in Front Cache. When a request fails due to an ARCUS failure, the Front Cache function can be worked. But, it is prone to data consistency issues, so we recommend using it only for data that doesn't change frequently. 
-  - false: If the change request of ARCUS fails, the change request is not reflected in Front Cache.
-   
+- `withArcusFrontCache(ArcusFrontCache arcusFrontCache)`
+  - Set the ArcusFrontCache object to enable Front Caching.
+  - The DefaultArcusFrontCache class provided by Arcus Spring can be used.
+  - Front caching is disabled by default and arguments cannot be set to null.
+- `withFrontExpireSeconds(int frontExpireSeconds)`
+  - Set Front Cache TTL(TimeToLive).
+- `enableForcingFrontCache()`, `disableForcingFrontCache()`
+  - Set whether to perform Front Cache regardless of success or failure of ARCUS change request(put, delete, clear).
+  - It is prone to data consistency issues, so we recommend using it only for data that doesn't change frequently.
+  - It is disabled by default.
+
 Front Caching is not always performed. It is performed depending on the attribute of `forceFrontCaching` property and the result of the ARCUS request.
 
 | ArcusCache API | ARCUS Result | forceFrontCaching=false | forceFrontCaching=true |

--- a/docs/03-arcus-spring-usage.md
+++ b/docs/03-arcus-spring-usage.md
@@ -139,22 +139,20 @@ public class ArcusConfiguration extends CachingConfigurerSupport {
 
   @Bean
   public ArcusCacheConfiguration testCacheConfig() {
-    ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-    cacheConfig.setServiceId("TEST-");
-    cacheConfig.setPrefix("PRODUCT");
-    cacheConfig.setExpireSeconds(60);
-    cacheConfig.setTimeoutMilliSeconds(800);
-    return cacheConfig;
+    return new ArcusCacheConfiguration()
+        .withServiceId("TEST-")
+        .withPrefix("PRODUCT")
+        .withExpireSeconds(60)
+        .withTimeoutMilliSeconds(800);
   }
 
   @Bean
   public ArcusCacheConfiguration devCacheConfig() {
-    ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-    cacheConfig.setServiceId("DEV-");
-    cacheConfig.setPrefix("PRODUCT");
-    cacheConfig.setExpireSeconds(120);
-    cacheConfig.setTimeoutMilliSeconds(800);
-    return cacheConfig;
+    return new ArcusCacheConfiguration()
+        .withServiceId("DEV-")
+        .withPrefix("PRODUCT")
+        .withExpireSeconds(120)
+        .withTimeoutMilliSeconds(800);
   }
 }
 ```
@@ -237,32 +235,30 @@ Front Cache 기능에 대한 설명은 [2장](02-arcus-spring-concept.md#front-c
 ```java
 @Bean
 public ArcusCacheConfiguration testCacheConfig() {
-  ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-  cacheConfig.setServiceId("TEST-");
-  cacheConfig.setPrefix("PRODUCT");
-  cacheConfig.setExpireSeconds(60);
-  cacheConfig.setTimeoutMilliSeconds(800);
-  /* front cache configuration */
-  cacheConfig.setArcusFrontCache(testArcusFrontCache());
-  cacheConfig.setFrontExpireSeconds(120);
-  cacheConfig.setForceFrontCaching(false);
-  /* front cache configuration */
-  return cacheConfig;
+  return new ArcusCacheConfiguration()
+      .withServiceId("TEST-")
+      .withPrefix("PRODUCT")
+      .withExpireSeconds(60)
+      .withTimeoutMilliSeconds(800)
+      /* front cache configuration */
+      .withArcusFrontCache(testArcusFrontCache())
+      .withFrontExpireSeconds(120)
+      .enableForcingFrontCache();
+      /* front cache configuration */
 }
 
 @Bean
 public ArcusCacheConfiguration devCacheConfig() {
-  ArcusCacheConfiguration cacheConfig = new ArcusCacheConfiguration();
-  cacheConfig.setServiceId("DEV-");
-  cacheConfig.setPrefix("PRODUCT");
-  cacheConfig.setExpireSeconds(120);
-  cacheConfig.setTimeoutMilliSeconds(800);
-  /* front cache configuration */
-  cacheConfig.setArcusFrontCache(devArcusFrontCache());
-  cacheConfig.setFrontExpireSeconds(240);
-  cacheConfig.setForceFrontCaching(true);
-  /* front cache configuration */
-  return cacheConfig;
+  return new ArcusCacheConfiguration()
+      .withServiceId("DEV-")
+      .withPrefix("PRODUCT")
+      .withExpireSeconds(120)
+      .withTimeoutMilliSeconds(800)
+      /* front cache configuration */
+      .withArcusFrontCache(devArcusFrontCache())
+      .withFrontExpireSeconds(240)
+      .enableForcingFrontCache();
+      /* front cache configuration */
 }
 
 @Bean

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -79,11 +79,6 @@ import org.springframework.util.DigestUtils;
 @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
 public class ArcusCache extends AbstractValueAdaptingCache {
 
-  public static final long DEFAULT_TIMEOUT_MILLISECONDS = 700L;
-  @Deprecated
-  public static final boolean DEFAULT_WANT_TO_GET_EXCEPTION = false;
-  public static final boolean DEFAULT_ALLOW_NULL_VALUES = true;
-
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private String name;
@@ -97,7 +92,7 @@ public class ArcusCache extends AbstractValueAdaptingCache {
    */
   @Deprecated
   public ArcusCache() {
-    super(DEFAULT_ALLOW_NULL_VALUES);
+    super(ArcusCacheConfiguration.DEFAULT_ALLOW_NULL_VALUES);
     this.configuration = new ArcusCacheConfiguration();
   }
 

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -23,28 +23,113 @@ import javax.annotation.Nullable;
 
 import net.spy.memcached.transcoders.Transcoder;
 
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
 @SuppressWarnings("DeprecatedIsStillUsed")
-public class ArcusCacheConfiguration implements InitializingBean {
+public class ArcusCacheConfiguration {
+
+  static final long DEFAULT_TIMEOUT_MILLISECONDS = 700L;
+  @Deprecated
+  static final boolean DEFAULT_WANT_TO_GET_EXCEPTION = false;
+  static final boolean DEFAULT_ALLOW_NULL_VALUES = true;
 
   private String serviceId = "";
+  @Nullable
   private String prefix;
   private int expireSeconds;
-  private int frontExpireSeconds;
-  private long timeoutMilliSeconds = ArcusCache.DEFAULT_TIMEOUT_MILLISECONDS;
+  private long timeoutMilliSeconds = DEFAULT_TIMEOUT_MILLISECONDS;
+  @Nullable
   private Transcoder<Object> operationTranscoder;
+  @Nullable
   private ArcusFrontCache arcusFrontCache;
-  @Deprecated
-  private boolean wantToGetException = ArcusCache.DEFAULT_WANT_TO_GET_EXCEPTION;
+  private int frontExpireSeconds = 5;
   private boolean forceFrontCaching;
-  private boolean allowNullValues = ArcusCache.DEFAULT_ALLOW_NULL_VALUES;
+  @Deprecated
+  private boolean wantToGetException = DEFAULT_WANT_TO_GET_EXCEPTION;
+  private boolean allowNullValues = DEFAULT_ALLOW_NULL_VALUES;
+
+  public ArcusCacheConfiguration() {
+  }
+
+  public ArcusCacheConfiguration withServiceId(String serviceId) {
+    Assert.notNull(serviceId, "ServiceId must not be null.");
+    this.serviceId = serviceId;
+    return this;
+  }
+
+  public ArcusCacheConfiguration withPrefix(String prefix) {
+    Assert.notNull(prefix, "Prefix must not be null.");
+    this.prefix = prefix;
+    return this;
+  }
+
+  public ArcusCacheConfiguration withExpireSeconds(int expireSeconds) {
+    Assert.isTrue(expireSeconds > -2, "ExpireSeconds must be positive integer, 0, or -1.");
+    this.expireSeconds = expireSeconds;
+    return this;
+  }
+
+  public ArcusCacheConfiguration withTimeoutMilliSeconds(long timeoutMilliSeconds) {
+    Assert.isTrue(timeoutMilliSeconds > 0, "TimeoutMilliSeconds must be larger than 0.");
+    this.timeoutMilliSeconds = timeoutMilliSeconds;
+    return this;
+  }
+
+  public ArcusCacheConfiguration withOperationTranscoder(Transcoder<Object> operationTranscoder) {
+    Assert.notNull(operationTranscoder, "OperationTranscoder must not be null.");
+    this.operationTranscoder = operationTranscoder;
+    return this;
+  }
+
+  public ArcusCacheConfiguration withArcusFrontCache(ArcusFrontCache arcusFrontCache) {
+    Assert.notNull(arcusFrontCache, "ArcusFrontCache must not be null.");
+    this.arcusFrontCache = arcusFrontCache;
+    return this;
+  }
+
+  public ArcusCacheConfiguration withFrontExpireSeconds(int frontExpireSeconds) {
+    Assert.isTrue(frontExpireSeconds > -1, "FrontExpireSeconds must not be negative integer.");
+    this.frontExpireSeconds = frontExpireSeconds;
+    return this;
+  }
+
+  public ArcusCacheConfiguration enableForcingFrontCache() {
+    this.forceFrontCaching = true;
+    return this;
+  }
+
+  public ArcusCacheConfiguration disableForcingFrontCache() {
+    this.forceFrontCaching = false;
+    return this;
+  }
+
+  @Deprecated
+  public ArcusCacheConfiguration enableGettingException() {
+    this.wantToGetException = true;
+    return this;
+  }
+
+  @Deprecated
+  public ArcusCacheConfiguration disableGettingException() {
+    this.wantToGetException = false;
+    return this;
+  }
+
+  public ArcusCacheConfiguration enableCachingNullValues() {
+    this.allowNullValues = true;
+    return this;
+  }
+
+  public ArcusCacheConfiguration disableCachingNullValues() {
+    this.allowNullValues = false;
+    return this;
+  }
 
   public String getServiceId() {
     return serviceId;
   }
 
+  @Deprecated
   public void setServiceId(String serviceId) {
     this.serviceId = serviceId;
   }
@@ -54,6 +139,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return prefix;
   }
 
+  @Deprecated
   public void setPrefix(@Nullable String prefix) {
     this.prefix = prefix;
   }
@@ -62,6 +148,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return expireSeconds;
   }
 
+  @Deprecated
   public void setExpireSeconds(int expireSeconds) {
     this.expireSeconds = expireSeconds;
   }
@@ -70,6 +157,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return frontExpireSeconds;
   }
 
+  @Deprecated
   public void setFrontExpireSeconds(int frontExpireSeconds) {
     this.frontExpireSeconds = frontExpireSeconds;
   }
@@ -78,7 +166,9 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return timeoutMilliSeconds;
   }
 
+  @Deprecated
   public void setTimeoutMilliSeconds(long timeoutMilliSeconds) {
+    Assert.isTrue(timeoutMilliSeconds > 0, "TimeoutMilliSeconds must be larger than 0.");
     this.timeoutMilliSeconds = timeoutMilliSeconds;
   }
 
@@ -87,6 +177,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return operationTranscoder;
   }
 
+  @Deprecated
   public void setOperationTranscoder(@Nullable Transcoder<Object> operationTranscoder) {
     this.operationTranscoder = operationTranscoder;
   }
@@ -96,6 +187,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return arcusFrontCache;
   }
 
+  @Deprecated
   public void setArcusFrontCache(@Nullable ArcusFrontCache arcusFrontCache) {
     this.arcusFrontCache = arcusFrontCache;
   }
@@ -114,6 +206,7 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return forceFrontCaching;
   }
 
+  @Deprecated
   public void setForceFrontCaching(boolean forceFrontCaching) {
     this.forceFrontCaching = forceFrontCaching;
   }
@@ -122,13 +215,9 @@ public class ArcusCacheConfiguration implements InitializingBean {
     return this.allowNullValues;
   }
 
+  @Deprecated
   public void setAllowNullValues(boolean allowNullValues) {
     this.allowNullValues = allowNullValues;
-  }
-
-  @Override
-  public void afterPropertiesSet() {
-    Assert.isTrue(timeoutMilliSeconds > 0, "TimeoutMilliSeconds must be larger than 0.");
   }
 
 }

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheConfigurationTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheConfigurationTest.java
@@ -1,0 +1,36 @@
+package com.navercorp.arcus.spring.cache;
+
+import net.spy.memcached.ArcusClient;
+import net.spy.memcached.ArcusClientPool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArcusCacheConfigurationTest {
+
+  @Test
+  void createValidCacheKey() {
+    ArcusCacheConfiguration config = new ArcusCacheConfiguration()
+            .withServiceId("TEST-")
+            .withPrefix("test1");
+    ArcusClientPool clientPool = ArcusClient.createArcusClientPool("localhost:2181", "test", 8);
+    ArcusCache arcusCache = new ArcusCache("cache1", clientPool, config);
+
+    assertTrue(arcusCache.createArcusKey("key1").startsWith("TEST-test1:key1"));
+  }
+
+  @Test
+  void failWhenSettingInvalidValueInConfigMethod() {
+    ArcusCacheConfiguration config = new ArcusCacheConfiguration();
+
+    assertThrows(IllegalArgumentException.class, () -> config.withServiceId(null));
+    assertThrows(IllegalArgumentException.class, () -> config.withPrefix(null));
+    assertThrows(IllegalArgumentException.class, () -> config.withExpireSeconds(-30));
+    assertThrows(IllegalArgumentException.class, () -> config.withTimeoutMilliSeconds(-1));
+    assertThrows(IllegalArgumentException.class, () -> config.withArcusFrontCache(null));
+    assertThrows(IllegalArgumentException.class, () -> config.withOperationTranscoder(null));
+  }
+
+}

--- a/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerBuilderTest.java
+++ b/src/test/java/com/navercorp/arcus/spring/cache/ArcusCacheManagerBuilderTest.java
@@ -22,8 +22,7 @@ class ArcusCacheManagerBuilderTest {
 
   @Test
   void testMissingCacheMadeByDefaultCacheConfig() {
-    ArcusCacheConfiguration configuration = new ArcusCacheConfiguration();
-    configuration.setServiceId("TEST-");
+    ArcusCacheConfiguration configuration = new ArcusCacheConfiguration().withServiceId("TEST-");
     ArcusCacheManager cm = ArcusCacheManager.builder(arcusClientPool).cacheDefaults(configuration).build();
     cm.afterPropertiesSet();
 
@@ -36,8 +35,7 @@ class ArcusCacheManagerBuilderTest {
 
   @Test
   void testSettingDifferentDefaultCacheConfiguration() {
-    ArcusCacheConfiguration withPrefix = new ArcusCacheConfiguration();
-    withPrefix.setPrefix("prefix");
+    ArcusCacheConfiguration withPrefix = new ArcusCacheConfiguration().withPrefix("prefix");
     ArcusCacheConfiguration withoutPrefix = new ArcusCacheConfiguration();
 
     ArcusCacheManager cm = ArcusCacheManager.builder(arcusClientPool)


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ArcusCacheConfiguration으로 사용자가 값을 설정할 때 setter 대신 withServiceId, enableFrontCaching 등의 메서드를 사용하도록 변경하고 해당 메서드 안에서 입력값을 검증하도록 합니다.
- 사용자 입장에서 코드가 좀 더 간결해진다는 장점이 있으며, Redis와 Couchbase와 비슷한 방식으로 사용할 수 있습니다.
- setter를 deprecate시키기 때문에, 나중에 setter가 제거되면 xml으로 ArcusCacheConfiguration의 각 필드를 설정할 수 없게 됩니다. 반드시 xml 빈 등록 방식을 지원해야 한다면 ArcusCacheConfigurationFactoryBean 클래스를 만들고 이 안에 setter를 두면 xml기반 설정 방식을 지원할 수 있습니다. 의견 부탁드립니다.
- 기존 ArcusCache에 있던 기본값들을 ArcusCacheConfiguration에서 더 많이 사용하므로 옮겼습니다.