### PR TITLE
INTERNAL: remove deprecation of wantToGetException

### DIFF
--- a/docs/02-arcus-spring-concept.md
+++ b/docs/02-arcus-spring-concept.md
@@ -83,8 +83,8 @@ ArcusCacheConfiguration 객체를 생성하고 아래 메소드를 통해 속성
   - 인자로 null을 입력할 수 없다.
 - `enableGettingException()` / `disableGettingException()`
   - ARCUS Client의 연산에서 발생하는 예외를 받을지 여부를 설정한다.
-  - 기본적으로 disable 상태이며 예외가 발생하면 원본 메서드를 수행하도록 한다. 
-  - enable시킬 경우 예외가 발생하면 그대로 반환하므로 직접 상황에 맞게 예외를 처리해주어야 한다.
+  - 기본적으로 disable 상태이며 예외가 발생하면 반환하지 않고 로깅만 하여, 원본 메서드가 수행되도록 한다. 단, InterruptedException의 경우 그대로 반환된다. 
+  - enable시킬 경우 예외가 발생하면 그대로 반환하므로, 직접 상황에 맞게 예외를 처리해주어야 한다.
 - `enableCachingNullValues()` / `disableCachingNullValues()`
   - 캐시 아이템의 값으로 null을 허용할지 여부를 설정한다.
   - 기본적으로 enable 상태이며 null 값을 NullValue 객체로 변환하여 캐시에 저장한다.

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -147,7 +147,7 @@ public class ArcusCache extends AbstractValueAdaptingCache {
     try {
       return getValue(arcusKey);
     } catch (Exception e) {
-      if (configuration.isWantToGetException()) {
+      if (e instanceof InterruptedException || configuration.isWantToGetException()) {
         throw toRuntimeException(e);
       }
       logger.info("failed to lookup. error: {}, key: {}", e.getMessage(), arcusKey);
@@ -200,7 +200,7 @@ public class ArcusCache extends AbstractValueAdaptingCache {
     try {
       putValue(arcusKey, toStoreValue(value));
     } catch (Exception e) {
-      if (configuration.isWantToGetException()) {
+      if (e instanceof InterruptedException || configuration.isWantToGetException()) {
         throw toRuntimeException(e);
       }
       logger.info("failed to put. error: {}, key: {}", e.getMessage(), arcusKey);
@@ -229,7 +229,7 @@ public class ArcusCache extends AbstractValueAdaptingCache {
     try {
       return putIfAbsentValue(arcusKey, toStoreValue(value));
     } catch (Exception e) {
-      if (configuration.isWantToGetException()) {
+      if (e instanceof InterruptedException || configuration.isWantToGetException()) {
         throw toRuntimeException(e);
       }
       logger.info("failed to putIfAbsent. error: {}, key: {}", e.getMessage(), arcusKey);
@@ -252,7 +252,7 @@ public class ArcusCache extends AbstractValueAdaptingCache {
         logger.info("failed to evict a key: {}, status: {}", arcusKey, status.getMessage());
       }
     } catch (Exception e) {
-      if (configuration.isWantToGetException()) {
+      if (e instanceof InterruptedException || configuration.isWantToGetException()) {
         throw toRuntimeException(e);
       }
       logger.info("failed to evict. error: {}, key: {}", e.getMessage(), arcusKey);
@@ -281,7 +281,7 @@ public class ArcusCache extends AbstractValueAdaptingCache {
         logger.info("failed to clear a prefix: {}, status: {}", arcusPrefix, status.getMessage());
       }
     } catch (Exception e) {
-      if (configuration.isWantToGetException()) {
+      if (e instanceof InterruptedException || configuration.isWantToGetException()) {
         throw toRuntimeException(e);
       }
       logger.info("failed to clear. error: {}, prefix: {}", e.getMessage(), arcusPrefix);

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCacheConfiguration.java
@@ -29,7 +29,6 @@ import org.springframework.util.Assert;
 public class ArcusCacheConfiguration {
 
   static final long DEFAULT_TIMEOUT_MILLISECONDS = 700L;
-  @Deprecated
   static final boolean DEFAULT_WANT_TO_GET_EXCEPTION = false;
   static final boolean DEFAULT_ALLOW_NULL_VALUES = true;
 
@@ -44,7 +43,6 @@ public class ArcusCacheConfiguration {
   private ArcusFrontCache arcusFrontCache;
   private int frontExpireSeconds = 5;
   private boolean forceFrontCaching;
-  @Deprecated
   private boolean wantToGetException = DEFAULT_WANT_TO_GET_EXCEPTION;
   private boolean allowNullValues = DEFAULT_ALLOW_NULL_VALUES;
 
@@ -103,13 +101,20 @@ public class ArcusCacheConfiguration {
     return this;
   }
 
-  @Deprecated
+  /**
+   * Throw exception when Arcus request failed by error, cancellation, timeout.
+   * If {@link java.lang.InterruptedException} occurred, it will be thrown.
+   * Exception should be handled by customarily.
+   */
   public ArcusCacheConfiguration enableGettingException() {
     this.wantToGetException = true;
     return this;
   }
 
-  @Deprecated
+  /**
+   * Do not throw exception when Arcus request failed by error, cancellation, timeout.
+   * Instead, log the details of exception at INFO level.
+   */
   public ArcusCacheConfiguration disableGettingException() {
     this.wantToGetException = false;
     return this;
@@ -192,7 +197,6 @@ public class ArcusCacheConfiguration {
     this.arcusFrontCache = arcusFrontCache;
   }
 
-  @Deprecated
   public boolean isWantToGetException() {
     return wantToGetException;
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/564

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- wantToGetException의 deprecation 을 제거하고 부활합니다.
- InterruptedException 발생 시에는 항상 예외를 발생하도록 합니다.
