### PR TITLE
FIX: remove stale dependency in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,14 +79,6 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-reload4j</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <!-- Spring -->


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Arcus Java Client 의존성에서 제외하지 않아도 되는 의존성이 있어 해당 부분을 제거합니다.
  - slf4j-log4j12, slf4j-reload4j 의존성은 ZooKeeper에 의해 생겨나는데, Arcus Java Client에서 ZooKeeper 의존성을 가져올 때 해당 두 의존성을 제외하기 때문에 Arcus Spring에서도 자연스럽게 제외되어있는 형태일 것입니다.