### PR TITLE
INTERNAL: support keepalive option in ArcusClientFactoryBean

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/ArcusClientFactoryBean.java
+++ b/src/main/java/com/navercorp/arcus/spring/ArcusClientFactoryBean.java
@@ -47,6 +47,7 @@ public class ArcusClientFactoryBean implements FactoryBean<ArcusClientPool>,
   private boolean frontCacheCopyOnWrite = DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
   private int timeoutExceptionThreshold = 100;
   private long maxReconnectDelay = DefaultConnectionFactory.DEFAULT_MAX_RECONNECT_DELAY;
+  private boolean keepAlive = false;
 
   /**
    * global transcoder for key/value store.
@@ -85,6 +86,17 @@ public class ArcusClientFactoryBean implements FactoryBean<ArcusClientPool>,
     this.maxReconnectDelay = maxReconnectDelay;
   }
 
+  /**
+   * Set the keepAlive property for Arcus connections.
+   *
+   * @param keepAlive if {@code true}, enables the TCP keep-alive feature for connections.
+   *                  This helps maintain long-lived connections by periodically sending
+   *                  keep-alive packets to detect broken links.
+   */
+  public void setKeepAlive(boolean keepAlive) {
+    this.keepAlive = keepAlive;
+  }
+
   public void setUrl(String url) {
     this.url = url;
   }
@@ -108,6 +120,7 @@ public class ArcusClientFactoryBean implements FactoryBean<ArcusClientPool>,
     cfb.setFrontCacheCopyOnRead(frontCacheCopyOnRead);
     cfb.setFrontCacheCopyOnWrite(frontCacheCopyOnWrite);
     cfb.setMaxReconnectDelay(maxReconnectDelay);
+    cfb.setKeepAlive(keepAlive);
     if (maxFrontCacheElements > 0) {
       cfb.setMaxFrontCacheElements(maxFrontCacheElements);
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-spring/issues/116

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ArcusClientFactoryBean에서 keepalive 옵션을 활성화할 수 있도록 수정합니다.
- +) java client에서 1.14.1 릴리즈 시 ehcache 옵션 설정이 변경될 예정입니다. arcus spring도 릴리즈 전 java client 1.14.1 버전을 사용하도록 변경할텐데, 이 FactoryBean도 함께 수정할 예정입니다.
